### PR TITLE
Fix for modal window bug

### DIFF
--- a/src/Picker.jsx
+++ b/src/Picker.jsx
@@ -198,7 +198,7 @@ const Picker = React.createClass({
     if (!this.calendarContainer) {
       this.calendarContainer = document.createElement('div');
       this.calendarContainer.className = `${this.props.prefixCls}-container`;
-      document.body.appendChild(this.calendarContainer);
+      this.getInputDOMNode().parentNode.appendChild(this.calendarContainer);
     }
     return this.calendarContainer;
   },


### PR DESCRIPTION
If calendar's container is attached to document.body when you click on a day in the calendar, the click event is bubbled from document.body  and not from the modal window's body. This causes the window modal closes.