### PR TITLE
fixed today-btn className

### DIFF
--- a/src/calendar/CalendarFooter.jsx
+++ b/src/calendar/CalendarFooter.jsx
@@ -31,7 +31,7 @@ class CalendarFooter extends React.Component {
       }
       if (props.showToday) {
         let disabledToday = false;
-        let disabledTodayClass;
+        let disabledTodayClass = '';
         if (props.disabledDate) {
           disabledToday = props.disabledDate(this.getTodayTime(), value);
           if (disabledToday) {


### PR DESCRIPTION
today 按钮在 `disabledToday` 值为 `false` 的情况下，`className` 含有 `'undefined'` [#282](https://github.com/ant-design/ant-design/issues/282#issuecomment-139986777)