### PR TITLE
add current month cell className, add month select cause

### DIFF
--- a/src/FullCalendar.jsx
+++ b/src/FullCalendar.jsx
@@ -40,7 +40,7 @@ const FullCalendar = React.createClass({
   },
   onMonthSelect(value) {
     this.setType('date');
-    this.onSelect(value);
+    this.onSelect(value, { target: 'month' });
   },
   setType(type) {
     this.setState({ type });

--- a/src/month/MonthTable.js
+++ b/src/month/MonthTable.js
@@ -60,6 +60,8 @@ class MonthTable extends Component {
   render() {
     const props = this.props;
     const value = this.state.value;
+    const today = value.clone();
+    today.setTime(Date.now());
     const months = this.getMonths();
     const currentMonth = value.getMonth();
     const {prefixCls, locale} = props;
@@ -75,6 +77,8 @@ class MonthTable extends Component {
           [`${prefixCls}-cell`]: 1,
           [`${prefixCls}-cell-disabled`]: disabled,
           [`${prefixCls}-selected-cell`]: monthData.value === currentMonth,
+          [`${prefixCls}-current-cell`]: today.getYear() === value.getYear() &&
+            monthData.value === today.getMonth(),
         };
         let cellEl;
         if (props.cellRender) {


### PR DESCRIPTION
- monthPanel作为一个单独展示用的面板，增加了当前月的className
- onSelect事件是monthPanel触发时，增加了第二个参数的属性{ target: 'month' }
- [https://github.com/ant-design/ant-design/pull/519#issuecomment-156462334](https://github.com/ant-design/ant-design/pull/519#issuecomment-156462334)