### PR TITLE
chore: add `~` for RangeCalendar

### DIFF
--- a/assets/common/RangeCalendar.less
+++ b/assets/common/RangeCalendar.less
@@ -1,5 +1,5 @@
 .@{prefixClass}-range {
-  width: 524px;
+  width: 502px;
   overflow: hidden;
 
   &-part {
@@ -21,6 +21,16 @@
 
   &-right {
     float: right;
+  }
+
+  &-middle {
+    position: absolute;
+    left: 50%;
+    width: 20px;
+    margin-left: -10px;
+    text-align: center;
+    height: 35px;
+    line-height: 35px;
   }
 
   .@{prefixClass}-in-range-cell {

--- a/src/RangeCalendar.js
+++ b/src/RangeCalendar.js
@@ -219,6 +219,7 @@ const RangeCalendar = React.createClass({
                                              onInputSelect={onInputSelect.bind(this, 'left')}
                                              onTimeSelect={onTimeSelect.bind(this, 'left')}
                                              onValueChange={onValueChange.bind(this, 'left')}/>
+      <span className={`${prefixCls}-range-middle`}>~</span>
       <CalendarPart {...props} {...newProps} direction="right"
                                              formatter={this.getFormatter()}
                                              value={this.getEndValue()}


### PR DESCRIPTION
RangeCalendar 中间应该要有一个 `~`，然后无法用样式实现，所以可能要加进 DOM 里。

![snip20151208_1](https://cloud.githubusercontent.com/assets/3580607/11647075/e2b0d924-9d9e-11e5-8e85-21a3f440ab0d.png)


