### PR TITLE
RangePicker improvement

### DIFF
--- a/assets/common/RangeCalendar.less
+++ b/assets/common/RangeCalendar.less
@@ -87,7 +87,7 @@
       }
       &-right {
         .@{prefixClass}-time-picker-panel {
-          left: 21px;
+          left: 36px;
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-calendar",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "React Calendar",
   "keywords": [
     "react",

--- a/src/calendar/TimePickerButton.jsx
+++ b/src/calendar/TimePickerButton.jsx
@@ -1,13 +1,22 @@
 import React from 'react';
+import classnames from 'classnames';
 
 export default function TimePickerButton({
   prefixCls, locale, showTimePicker,
-  onOpenTimePicker, onCloseTimePicker }) {
-  const className = `${prefixCls}-time-picker-btn`;
+  onOpenTimePicker, onCloseTimePicker, timePickerDisabled }) {
+  const className = classnames({
+    [`${prefixCls}-time-picker-btn`]: true,
+    [`${prefixCls}-time-picker-btn-disabled`]: timePickerDisabled,
+  });
+  let onClick = null;
+  if (!timePickerDisabled) {
+    onClick = showTimePicker ? onCloseTimePicker : onOpenTimePicker;
+  }
   return (<a
     className={className}
     role="button"
-    onClick={showTimePicker ? onCloseTimePicker : onOpenTimePicker}
+    onClick={onClick}
+    disabled={timePickerDisabled}
   >
     {showTimePicker ? locale.dateSelect : locale.timeSelect}
   </a>);

--- a/src/range-calendar/CalendarPart.js
+++ b/src/range-calendar/CalendarPart.js
@@ -20,12 +20,13 @@ const CalendarPart = React.createClass({
     disabledDate: PropTypes.any,
     timePicker: PropTypes.any,
     disabledTime: PropTypes.any,
+    timePickerDisabledTime: PropTypes.func,
   },
   render() {
     const props = this.props;
     const { value, direction, prefixCls,
       locale, selectedValue, formatter, placeholder,
-      disabledDate, timePicker, disabledTime, showTimePicker } = props;
+      disabledDate, timePicker, disabledTime, timePickerDisabledTime, showTimePicker } = props;
     const disabledTimeConfig = disabledTime && timePicker ?
       getTimeConfig(selectedValue, disabledTime) : null;
     const rangeClassName = `${prefixCls}-range`;
@@ -48,6 +49,7 @@ const CalendarPart = React.createClass({
       disabledMinutes: noop,
       disabledSeconds: noop,
       ...disabledTimeConfig,
+      ...timePickerDisabledTime,
     });
 
     return (<div className={`${rangeClassName}-part ${rangeClassName}-${direction}`}>

--- a/src/range-calendar/CalendarPart.js
+++ b/src/range-calendar/CalendarPart.js
@@ -20,7 +20,7 @@ const CalendarPart = React.createClass({
     disabledDate: PropTypes.any,
     timePicker: PropTypes.any,
     disabledTime: PropTypes.any,
-    timePickerDisabledTime: PropTypes.func,
+    timePickerDisabledTime: PropTypes.object,
   },
   render() {
     const props = this.props;


### PR DESCRIPTION
* 日期面板：
  * 只选中开始日期，“确定”和“选择时间”灰置。
  * 如未选择日期直接选择时间，开始日期和结束日期默认选中当天。
  * 点击框外和确定均为确定操作。

* 时间面板：
  * 在时间页面，开始时间的默认状态为当前时间，结束时间的默认状态跟随开始时间。
  * 开始时间的选择范围没有限制，结束时间的选择范围必须大于等于开始时间。
  * 当开始时间选择了结束时间之后的时间（发生冲突），结束时间则自动切换到与开始时间相同的时间。