### PR TITLE
add single day option to rangeCalendar

### DIFF
--- a/assets/common/RangeCalendar.less
+++ b/assets/common/RangeCalendar.less
@@ -127,4 +127,13 @@
   .@{prefixClass}-today-btn {
     float: left;
   }
+  .@{prefixClass}-single-day-checkbox-label {
+    float: left;
+    margin-left: 5px;
+  }
+  .@{prefixClass}-single-day-checkbox {
+    float: left;
+    margin-left: 20px;
+    margin-top: 2px;
+  }
 }

--- a/src/RangeCalendar.js
+++ b/src/RangeCalendar.js
@@ -6,6 +6,7 @@ import { syncTime, getTodayTime } from './util/';
 import TodayButton from './calendar/TodayButton';
 import OkButton from './calendar/OkButton';
 import TimePickerButton from './calendar/TimePickerButton';
+import SingleDayCheckbox from './calendar/SingleDayCheckbox';
 import CommonMixin from './mixin/CommonMixin';
 
 function noop() {
@@ -61,6 +62,10 @@ function onInputSelect(direction, value) {
   if (this.state.showTimePicker && selectedValue[0] && !selectedValue[1]) {
     selectedValue[1] = selectedValue[0];
   }
+  if (selectedValue[0] && this.state.singleDay) {
+    selectedValue[1] = selectedValue[0];
+  }
+
   this.fireSelectValueChange(selectedValue);
 }
 
@@ -72,6 +77,8 @@ const RangeCalendar = React.createClass({
     timePicker: PropTypes.any,
     value: PropTypes.any,
     showOk: PropTypes.bool,
+    showSingleDay: PropTypes.bool,
+    singleDay: PropTypes.bool,
     selectedValue: PropTypes.array,
     defaultSelectedValue: PropTypes.array,
     onOk: PropTypes.func,
@@ -90,17 +97,20 @@ const RangeCalendar = React.createClass({
     return {
       defaultSelectedValue: [],
       onValueChange: noop,
+      showSingleDay: true,
     };
   },
 
   getInitialState() {
     const props = this.props;
+    const singleDay = props.singleDay || false;
     const selectedValue = props.selectedValue || props.defaultSelectedValue;
     const value = normalizeAnchor(props, 1);
     return {
       selectedValue,
       value,
       showTimePicker: false,
+      singleDay,
     };
   },
 
@@ -134,6 +144,11 @@ const RangeCalendar = React.createClass({
     } else if (this.compare(selectedValue[0], value) > 0) {
       selectedValue.length = 1;
       selectedValue[0] = value;
+      changed = true;
+    }
+    if (this.state.singleDay && selectedValue.length === 1) {
+      selectedValue.length = 2;
+      selectedValue[1] = selectedValue[0];
       changed = true;
     }
     if (changed) {
@@ -173,6 +188,11 @@ const RangeCalendar = React.createClass({
   },
   onOk() {
     this.props.onOk(this.state.selectedValue);
+  },
+  onSingleDayToggle() {
+    this.setState({
+      singleDay: !this.state.singleDay,
+    });
   },
 
   getStartValue() {
@@ -270,7 +290,14 @@ const RangeCalendar = React.createClass({
     const props = this.props;
     const state = this.state;
     const { showTimePicker } = state;
-    const { prefixCls, dateInputPlaceholder, timePicker, showOk, locale, showClear } = props;
+    const {
+            prefixCls,
+            dateInputPlaceholder,
+            timePicker, showOk,
+            showSingleDay,
+            locale,
+            showClear,
+          } = props;
     const className = {
       [props.className]: !!props.className,
       [prefixCls]: 1,
@@ -358,6 +385,13 @@ const RangeCalendar = React.createClass({
             onToday={this.onToday}
             text={locale.backToToday}
           />
+          {!!showSingleDay ?
+            <SingleDayCheckbox
+              {...props}
+              prefixCls={prefixCls}
+              singleDay={this.state.singleDay}
+              onSingleDayToggle={this.onSingleDayToggle}
+            /> : null}
           {!!props.timePicker ?
             <TimePickerButton
               {...props}

--- a/src/calendar/SingleDayCheckbox.jsx
+++ b/src/calendar/SingleDayCheckbox.jsx
@@ -1,0 +1,27 @@
+import React, { PropTypes } from 'react';
+
+const SingleDayCheckbox = React.createClass({
+  propTypes: {
+    prefixCls: PropTypes.string,
+    singleDay: PropTypes.bool,
+    onSingleDayToggle: PropTypes.func,
+  },
+
+  render() {
+    return (
+      <div>
+        <input type="checkbox"
+          className={`${this.props.prefixCls}-single-day-checkbox`}
+          role="checkbox"
+          checked={this.props.singleDay}
+          onChange={() => { this.props.onSingleDayToggle(); }}
+        />
+        <label className={`${this.props.prefixCls}-single-day-checkbox-label`}>
+          Single-day Event
+        </label>
+      </div>
+    );
+  },
+});
+
+export default SingleDayCheckbox;

--- a/tests/RangeCalendar.spec.jsx
+++ b/tests/RangeCalendar.spec.jsx
@@ -109,4 +109,34 @@ describe('RangeCalendar', () => {
     Simulate.click(day);
     expect(ReactDOM.findDOMNode(rightInput).value).to.be('2015-10-02');
   });
+
+  it('singleDayOnSelect works', (done) => {
+    let day;
+
+    function onSelect(d) {
+      expect(d[0].format(format)).to.be('2015-09-04');
+      expect(d[1].format(format)).to.be('2015-09-04');
+      done();
+    }
+
+    const now = moment([2015, 8, 29]);
+    ReactDOM.unmountComponentAtNode(container);
+    calendar = ReactDOM.render(<RangeCalendar
+      format={format}
+      onSelect={onSelect}
+      defaultValue={now}
+      singleDay
+      showWeekNumber
+    />, container);
+    const leftCalendar = TestUtils.scryRenderedDOMComponentsWithClass(calendar,
+      'rc-calendar-range-left')[0];
+    const leftInput = $(leftCalendar).find('.rc-calendar-input')[0];
+    const rightCalendar = TestUtils.scryRenderedDOMComponentsWithClass(calendar,
+      'rc-calendar-range-right')[0];
+    const rightInput = $(rightCalendar).find('.rc-calendar-input')[0];
+    day = $(leftCalendar).find('.rc-calendar-date')[5]; // 9.4
+    Simulate.click(day);
+    expect(ReactDOM.findDOMNode(leftInput).value).to.be('2015-09-04');
+    expect(ReactDOM.findDOMNode(rightInput).value).to.be('2015-09-04');
+  });
 });


### PR DESCRIPTION
This adds a checkbox to the calendar footer to enable switching between range dates and single dates on the range calendar.  When singleDay is enabled, the endDate is automatically added onSelect.