### PR TITLE
Fix focus issue when the calendarInstance is null

### DIFF
--- a/src/Picker.jsx
+++ b/src/Picker.jsx
@@ -181,7 +181,7 @@ const Picker = React.createClass({
   },
 
   focusCalendar() {
-    if (this.state.open) {
+    if (this.state.open && this.calendarInstance !== null) {
       this.calendarInstance.focus();
     }
   },


### PR DESCRIPTION
I'm seeing some exception like `this.calendarInstance.focus is not a function` when using the component.
Looks like there is a concurrency with React that is calling the ref callback method with a `null` value during the unmounting to prevent memory leaks.