### PR TITLE
fix: RangePicker里按年切换日期后，再点击Back to today无效。

### DIFF
--- a/src/RangeCalendar.js
+++ b/src/RangeCalendar.js
@@ -374,8 +374,10 @@ const RangeCalendar = React.createClass({
     const startValue = this.getStartValue();
     const endValue = this.getEndValue();
     const thisMonth = getTodayTime(startValue).month();
-    const isTodayInView = thisMonth === startValue.month() ||
-      thisMonth === endValue.month();
+    const thisYear = getTodayTime(startValue).year();
+    const isThisYear = thisYear === startValue.year() || this.year === endValue.year();
+    const isTodayInView = isThisYear && (thisMonth === startValue.month() ||
+      thisMonth === endValue.month());
 
     return (
       <div


### PR DESCRIPTION
- fix https://github.com/ant-design/ant-design/issues/3410