### PR TITLE
Disabled time for range picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ http://react-component.github.io/calendar/examples/index.html
         </tr>
         <tr>
           <td>disabledTime</td>
-          <td>Function(current:moment):Object</td>
+          <td>Function(current:moment, partial:'left'|'right'):Object</td>
           <td></td>
           <td>a function which return a object with member of disabledHours/disabledMinutes/disabledSeconds according to rc-time-picker</td>
         </tr>

--- a/examples/antd-range-calendar.js
+++ b/examples/antd-range-calendar.js
@@ -51,10 +51,10 @@ function disabledDate(current) {
 function disabledTime(time, type) {
   if (type === 'left') {
     return {
-      disabledHours() { 
+      disabledHours() {
         const hours = newArray(0, 60);
         hours.splice(20, 4);
-        return hours; 
+        return hours;
       },
       disabledMinutes(h) {
         if (h === 20) {
@@ -64,14 +64,14 @@ function disabledTime(time, type) {
         }
         return [];
       },
-      disabledSeconds() { return [55, 56]},
-    }
-  } 
+      disabledSeconds() { return [55, 56]; },
+    };
+  }
   return {
-    disabledHours() { 
+    disabledHours() {
       const hours = newArray(0, 60);
       hours.splice(2, 6);
-      return hours; 
+      return hours;
     },
     disabledMinutes(h) {
       if (h === 20) {
@@ -81,8 +81,8 @@ function disabledTime(time, type) {
       }
       return [];
     },
-    disabledSeconds() { return [55, 56]},
-  }
+    disabledSeconds() { return [55, 56]; },
+  };
 }
 
 function format(v) {

--- a/examples/antd-range-calendar.js
+++ b/examples/antd-range-calendar.js
@@ -32,12 +32,57 @@ defaultCalendarValue.add(-1, 'month');
 
 const timePickerElement = <TimePickerPanel />;
 
+function newArray(start, end) {
+  const result = [];
+  for (let i = start; i < end; i++) {
+    result.push(i);
+  }
+  return result;
+}
+
 function disabledDate(current) {
   const date = moment();
   date.hour(0);
   date.minute(0);
   date.second(0);
   return current.isBefore(date);  // can not select days before today
+}
+
+function disabledTime(time, type) {
+  if (type === 'left') {
+    return {
+      disabledHours() { 
+        const hours = newArray(0, 60);
+        hours.splice(20, 4);
+        return hours; 
+      },
+      disabledMinutes(h) {
+        if (h === 20) {
+          return newArray(0, 31);
+        } else if (h === 23) {
+          return newArray(30, 60);
+        }
+        return [];
+      },
+      disabledSeconds() { return [55, 56]},
+    }
+  } 
+  return {
+    disabledHours() { 
+      const hours = newArray(0, 60);
+      hours.splice(2, 6);
+      return hours; 
+    },
+    disabledMinutes(h) {
+      if (h === 20) {
+        return newArray(0, 31);
+      } else if (h === 23) {
+        return newArray(30, 60);
+      }
+      return [];
+    },
+    disabledSeconds() { return [55, 56]},
+  }
 }
 
 function format(v) {
@@ -77,7 +122,7 @@ const Test = React.createClass({
         dateInputPlaceholder={['start', 'end']}
         defaultValue={[now, now]}
         locale={cn ? zhCN : enUS}
-        disabledDate={disabledDate}
+        disabledTime={disabledTime}
         timePicker={timePickerElement}
       />
     );
@@ -122,6 +167,7 @@ ReactDOM.render(
         onSelect={onStandaloneSelect}
         disabledDate={disabledDate}
         timePicker={timePickerElement}
+        disabledTime={disabledTime}
       />
     </div>
     <br />

--- a/src/RangeCalendar.js
+++ b/src/RangeCalendar.js
@@ -330,7 +330,7 @@ const RangeCalendar = React.createClass({
     const state = this.state;
     const { showTimePicker } = state;
     const {
-      prefixCls, dateInputPlaceholder,
+      prefixCls, dateInputPlaceholder, disabledTime,
       timePicker, showOk, locale, showClear,
       type,
     } = props;
@@ -403,6 +403,7 @@ const RangeCalendar = React.createClass({
               {...newProps}
               hoverValue={hoverValue}
               direction="left"
+              disabledTime={(time) => disabledTime(time, 'left')}
               format={this.getFormat()}
               value={startValue}
               placeholder={placeholder1}
@@ -425,6 +426,7 @@ const RangeCalendar = React.createClass({
               onValueChange={onValueChange.bind(this, 'right')}
               timePicker={timePicker}
               showTimePicker={showTimePicker}
+              disabledTime={(time) => disabledTime(time, 'right')}
             />
           </div>
           <div className={cls}>

--- a/src/RangeCalendar.js
+++ b/src/RangeCalendar.js
@@ -78,6 +78,7 @@ const RangeCalendar = React.createClass({
     format: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
     onClear: PropTypes.func,
     type: PropTypes.any,
+    disabledTime: PropTypes.func,
   },
 
   mixins: [CommonMixin],

--- a/src/range-calendar/CalendarPart.js
+++ b/src/range-calendar/CalendarPart.js
@@ -44,9 +44,9 @@ const CalendarPart = React.createClass({
       React.cloneElement(timePicker, {
         showHour: true,
         showSecond: true,
+        ...timePicker.props,
         ...disabledTimeConfig,
         ...timePickerDisabledTime,
-        ...timePicker.props,
         onChange: props.onInputSelect,
         defaultOpenValue: value,
         value: selectedValue[index],


### PR DESCRIPTION
- close #https://github.com/ant-design/ant-design/issues/3392

`disabledTime(time:moment, partial: 'left'|'right')` ，单独控制左右两边的 disabledTime 

https://github.com/RaoHai/calendar/blob/disabledTime4RangePicker/examples/antd-range-calendar.js#L51