### PR TITLE
fix: should not override disableTimeConfig

### DIFF
--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -203,8 +203,8 @@ const Calendar = React.createClass({
     const timePickerEle = timePicker && showTimePicker ? React.cloneElement(timePicker, {
       showHour: true,
       showSecond: true,
-      ...disabledTimeConfig,
       ...timePicker.props,
+      ...disabledTimeConfig,
       onChange: this.onDateInputChange,
       defaultOpenValue: value,
       value: selectedValue,


### PR DESCRIPTION
TimePicker 的 defaultProps 里面有 disabledHours 之类，所以要调整顺序，以免被覆盖。