### PR TITLE
 OkButton disable logic fix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.check.workspaceVersion": false
+}

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -208,6 +208,7 @@ const Calendar = React.createClass({
       onChange: this.onDateInputChange,
       defaultOpenValue: value,
       value: selectedValue,
+      disabledTime,
     }) : null;
     const dateInputElement = props.showDateInput ? (
       <DateInput
@@ -271,6 +272,7 @@ const Calendar = React.createClass({
             selectedValue={selectedValue}
             value={value}
             disabledDate={disabledDate}
+            okDisabled={!this.isAllowedDate(selectedValue)}
             onOk={this.onOk}
             onSelect={this.onSelect}
             onToday={this.onToday}

--- a/src/RangeCalendar.js
+++ b/src/RangeCalendar.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react';
 import moment from 'moment';
 import classnames from 'classnames';
 import CalendarPart from './range-calendar/CalendarPart';
-import { syncTime, getTodayTime } from './util/';
+import { syncTime, getTodayTime, isAllowedDate } from './util/';
 import TodayButton from './calendar/TodayButton';
 import OkButton from './calendar/OkButton';
 import TimePickerButton from './calendar/TimePickerButton';
@@ -76,6 +76,7 @@ const RangeCalendar = React.createClass({
     onChange: PropTypes.func,
     onSelect: PropTypes.func,
     onValueChange: PropTypes.func,
+    disabledDate: PropTypes.func,
     format: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
     onClear: PropTypes.func,
     type: PropTypes.any,
@@ -220,8 +221,12 @@ const RangeCalendar = React.createClass({
       showTimePicker: false,
     });
   },
+
   onOk() {
-    this.props.onOk(this.state.selectedValue);
+    const { selectedValue } = this.state;
+    if (this.isAllowedDateAndTime(selectedValue)) {
+      this.props.onOk(this.state.selectedValue);
+    }
   },
 
   onStartInputSelect(...oargs) {
@@ -300,6 +305,11 @@ const RangeCalendar = React.createClass({
       };
     }
     return null;
+  },
+
+  isAllowedDateAndTime(selectedValue) {
+    return isAllowedDate(selectedValue[0], this.props.disabledDate, this.disabledStartTime) &&
+    isAllowedDate(selectedValue[1], this.props.disabledDate, this.disabledEndTime);
   },
 
   hasSelectedValue() {
@@ -500,7 +510,9 @@ const RangeCalendar = React.createClass({
                     {...props}
                     value={state.value}
                     onOk={this.onOk}
-                    okDisabled={!this.hasSelectedValue() || hoverValue.length}
+                    okDisabled={!this.isAllowedDateAndTime(selectedValue) ||
+                      !this.hasSelectedValue() || hoverValue.length
+                    }
                   /> : null}
               </div>
             ) : null}

--- a/src/range-calendar/CalendarPart.js
+++ b/src/range-calendar/CalendarPart.js
@@ -43,6 +43,7 @@ const CalendarPart = React.createClass({
     const timePickerEle = showTimePicker && timePicker &&
       React.cloneElement(timePicker, {
         showHour: true,
+        showMinute: true,
         showSecond: true,
         ...timePicker.props,
         ...disabledTimeConfig,


### PR DESCRIPTION
+ close https://github.com/ant-design/ant-design/issues/3839 。
+ Calendar 的 timepicker 按照 Calender 的 disabledTime 进行禁用。
+ OK 按钮的 disabled 状态将全部按照  isAllowedDate规则校验。
   如果当前选取的时间非法，则该按钮禁用。