### PR TITLE
fix: rangeCalendar clear bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ npm start
 
 ## Example
 
-http://localhost:8001/examples/
+http://localhost:8002/examples/
 
 online example:
 
@@ -299,6 +299,12 @@ http://react-component.github.io/calendar/examples/index.html
           <td>Boolean</td>
           <td>auto</td>
           <td>whether has ok button in footer</td>
+        </tr>
+        <tr>
+          <td>showClear</td>
+          <td>Boolean</td>
+          <td>false</td>
+          <td>whether has clear button in header</td>
         </tr>
         <tr>
           <td>timePicker</td>

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -203,6 +203,7 @@ const Calendar = React.createClass({
     const timePickerEle = timePicker && showTimePicker ? React.cloneElement(timePicker, {
       showHour: true,
       showSecond: true,
+      showMinute: true,
       ...timePicker.props,
       ...disabledTimeConfig,
       onChange: this.onDateInputChange,

--- a/src/RangeCalendar.js
+++ b/src/RangeCalendar.js
@@ -335,7 +335,7 @@ const RangeCalendar = React.createClass({
     if (!this.state.selectedValue[0] || !this.state.selectedValue[1]) {
       this.setState({
         selectedValue,
-        value: selectedValue[0],
+        value: selectedValue[0] || getNow(),
       });
     }
 


### PR DESCRIPTION
## 重现步骤
- Demo页： http://react-component.github.io/calendar/examples/antd-range-calendar.html ,
- 不选择任何日期，直接点击clear，会throw error

## 原因
- onClick时 https://github.com/react-component/calendar/blob/master/src/RangeCalendar.js#L367 将 `this.state.value ` 置为了`undefined`
- 导致Render的时候throw error， 因为 https://github.com/react-component/calendar/blob/master/src/RangeCalendar.js#L427 方法内要求 `this.state.value` 必须是一个Moment对象

## 修复方案
- clear的时候将 `this.state.value` 设置为 `initialState` 的状态，即当前时间