### PR TITLE
replace moment i18n source

### DIFF
--- a/src/date/DateTBody.jsx
+++ b/src/date/DateTBody.jsx
@@ -49,7 +49,7 @@ const DateTBody = React.createClass({
     const {
       contentRender, prefixCls, selectedValue, value,
       showWeekNumber, dateRender, disabledDate,
-      hoverValue,
+      hoverValue, locale
     } = props;
     let iIndex;
     let jIndex;
@@ -71,7 +71,8 @@ const DateTBody = React.createClass({
     const month1 = value.clone();
     month1.date(1);
     const day = month1.day();
-    const lastMonthDiffDay = (day + 7 - value.localeData().firstDayOfWeek()) % 7;
+    const localeData = locale.localeData || value.localeData()
+    const lastMonthDiffDay = (day + 7 - localeData.firstDayOfWeek()) % 7;
     // calculate last month
     const lastMonth1 = month1.clone();
     lastMonth1.add(0 - lastMonthDiffDay, 'days');

--- a/src/date/DateTBody.jsx
+++ b/src/date/DateTBody.jsx
@@ -71,7 +71,7 @@ const DateTBody = React.createClass({
     const month1 = value.clone();
     month1.date(1);
     const day = month1.day();
-    const localeData = locale.localeData || value.localeData()
+    const localeData = locale.localeData || value.localeData();
     const lastMonthDiffDay = (day + 7 - localeData.firstDayOfWeek()) % 7;
     // calculate last month
     const lastMonth1 = month1.clone();

--- a/src/date/DateTBody.jsx
+++ b/src/date/DateTBody.jsx
@@ -36,6 +36,7 @@ const DateTBody = React.createClass({
     value: PropTypes.object,
     hoverValue: PropTypes.any,
     showWeekNumber: PropTypes.bool,
+    locale: PropTypes.object,
   },
 
   getDefaultProps() {

--- a/src/date/DateTBody.jsx
+++ b/src/date/DateTBody.jsx
@@ -50,7 +50,7 @@ const DateTBody = React.createClass({
     const {
       contentRender, prefixCls, selectedValue, value,
       showWeekNumber, dateRender, disabledDate,
-      hoverValue, locale
+      hoverValue, locale,
     } = props;
     let iIndex;
     let jIndex;

--- a/src/date/DateTHead.jsx
+++ b/src/date/DateTHead.jsx
@@ -7,7 +7,7 @@ class DateTHead extends React.Component {
   render() {
     const props = this.props;
     const value = props.value;
-    const localeData = value.localeData();
+    const localeData = props.locale.localeData || value.localeData();
     const prefixCls = props.prefixCls;
     const veryShortWeekdays = [];
     const weekDays = [];

--- a/src/full-calendar/CalendarHeader.jsx
+++ b/src/full-calendar/CalendarHeader.jsx
@@ -42,7 +42,7 @@ class CalendarHeader extends Component {
 
   monthSelectElement(month) {
     const props = this.props;
-    const localeData = props.value.localeData();
+    const localeData = props.locale.localeData || props.value.localeData();
     const t = props.value.clone();
     const { prefixCls } = props;
     const options = [];

--- a/src/month/MonthTable.js
+++ b/src/month/MonthTable.js
@@ -43,7 +43,7 @@ class MonthTable extends Component {
     const value = this.state.value;
     const current = value.clone();
     const months = [];
-    const localeData = value.localeData();
+    const localeData = this.props.locale.localeData || value.localeData();
     let index = 0;
     for (let rowIndex = 0; rowIndex < ROW; rowIndex++) {
       months[rowIndex] = [];

--- a/src/month/MonthTable.js
+++ b/src/month/MonthTable.js
@@ -135,5 +135,6 @@ MonthTable.propTypes = {
   cellRender: PropTypes.func,
   prefixCls: PropTypes.string,
   value: PropTypes.object,
+  locale: PropTypes.object,
 };
 export default MonthTable;


### PR DESCRIPTION
当datepicker通过clear清除value时，i18n无法保持
建议所有i18n相关翻译统一由props.locale字段传入