### PR TITLE
Add fix for issue #156 - display correct start date in CalendarHeader

### DIFF
--- a/src/RangeCalendar.js
+++ b/src/RangeCalendar.js
@@ -257,6 +257,9 @@ const RangeCalendar = React.createClass({
       value = value.clone();
       syncTime(selectedValue[0], value);
     }
+    if (this.state.showTimePicker && selectedValue[0]) {
+      return selectedValue[0];
+    }
     return value;
   },
 


### PR DESCRIPTION
This issue occurs in RangeCalendar. getStartDate() will get the initially picked start date from props.value even if a new date range has been picked. This causes the CalendarHeader to display the incorrect date when using TimePicker. This fix checks to see if a new selected start value exists and passes that to CalendarPart (and CalendarHeader) instead.