### PR TITLE
Add property "focusCalendarOnOpen" on Picker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,12 @@ http://react-component.github.io/calendar/examples/index.html
           <td>current open state of picker. controlled prop</td>
         </tr>
         <tr>
+          <td>focusCalendarOnOpen</td>
+          <td>Boolean</td>
+          <td>true</td>
+          <td>set focus on calendar element when its opened</td>
+        </tr>
+        <tr>
           <td>getCalendarContainer</td>
           <td>() => HTMLElement</td>
           <td>() => {return document.body;}</td>

--- a/src/Picker.jsx
+++ b/src/Picker.jsx
@@ -24,6 +24,7 @@ const Picker = React.createClass({
     calendar: PropTypes.element,
     style: PropTypes.object,
     open: PropTypes.bool,
+    focusCalendarOnOpen: PropTypes.bool,
     defaultOpen: PropTypes.bool,
     prefixCls: PropTypes.string,
     placement: PropTypes.any,
@@ -47,6 +48,7 @@ const Picker = React.createClass({
       defaultOpen: false,
       onChange: noop,
       onOpenChange: noop,
+      focusCalendarOnOpen: true,
     };
   },
 
@@ -81,7 +83,7 @@ const Picker = React.createClass({
   },
 
   componentDidUpdate(_, prevState) {
-    if (!prevState.open && this.state.open) {
+    if (!prevState.open && this.state.open && this.props.focusCalendarOnOpen) {
       this.focusCalendar();
     }
   },


### PR DESCRIPTION
If we have a css for different states of the input field (:focus as example), then when open the calendar, we get a blinking input field because focus automatically set to calendar element. It's annoying.

I suggest allow to disable this behaviour by adding the property "focusCalendarOnOpen" on Picker.