### PR TITLE
add rc-calendar-current-week classname

### DIFF
--- a/src/date/DateTBody.jsx
+++ b/src/date/DateTBody.jsx
@@ -218,7 +218,7 @@ const DateTBody = React.createClass({
         <tr
           key={iIndex}
           role="row"
-          className={ isCurrentWeek && `${prefixCls}-current-week` }
+          className={isCurrentWeek && `${prefixCls}-current-week`}
         >
           {weekNumberCell}
           {dateCells}

--- a/src/date/DateTBody.jsx
+++ b/src/date/DateTBody.jsx
@@ -91,6 +91,7 @@ const DateTBody = React.createClass({
     passed = 0;
 
     for (iIndex = 0; iIndex < DateConstants.DATE_ROW_COUNT; iIndex++) {
+      let isCurrentWeek;
       let weekNumberCell;
       const dateCells = [];
       if (showWeekNumber) {
@@ -120,6 +121,7 @@ const DateTBody = React.createClass({
 
         if (isSameDay(current, today)) {
           cls += ` ${todayClass}`;
+          isCurrentWeek = true;
         }
 
         const isBeforeCurrentMonthYear = beforeCurrentMonthYear(current, value);
@@ -216,6 +218,7 @@ const DateTBody = React.createClass({
         <tr
           key={iIndex}
           role="row"
+          className={ isCurrentWeek && `${prefixCls}-current-week` }
         >
           {weekNumberCell}
           {dateCells}


### PR DESCRIPTION
Add a css class name for current week <tr> element to allow styling.

Close: https://github.com/react-component/calendar/issues/218