### PR TITLE
Fix the click trigger order

### DIFF
--- a/src/calendar/CalendarHeader.jsx
+++ b/src/calendar/CalendarHeader.jsx
@@ -65,11 +65,13 @@ const CalendarHeader = createReactClass({
   },
 
   onSelect(value) {
-    this.triggerPanelChange({
-      showMonthPanel: 0,
-      showYearPanel: 0,
-    });
-    this.props.onValueChange(value);
+    setTimeout(() => {
+      this.triggerPanelChange({
+        showMonthPanel: 0,
+        showYearPanel: 0,
+      });
+      this.props.onValueChange(value);
+    }, 0);
   },
 
   triggerPanelChange(panelStatus) {


### PR DESCRIPTION
**Version Info**
OS: Mac OS X 10.12.4, Windows 7 SP1 64bit
Browsers: Chrome/57.0.2987.133 (64-bit), 
React Version: 15.5.4
rc-calendar: 8.1.3

**Reproduce the steps**
1. Click date input open DatePicker panel.
1. Click the year or month selector.
1. Choose one.
1. DatePicker panel was closed, but date input dose not change.

**Trace**
Before:
![image](https://cloud.githubusercontent.com/assets/3997851/25983823/b4a1a5de-3719-11e7-99d6-271ac0a9c743.png)

After:
![image](https://cloud.githubusercontent.com/assets/3997851/25983950/59500968-371a-11e7-82d4-65ce8a587e30.png)
