### PR TITLE
Change day cell title string formatting from hardcoded to moment#format

### DIFF
--- a/src/util/index.js
+++ b/src/util/index.js
@@ -19,7 +19,7 @@ export function getTodayTime(value) {
 }
 
 export function getTitleString(value) {
-  return `${value.year()}-${value.month() + 1}-${value.date()}`;
+  return value.format('L');
 }
 
 export function getTodayTimeStr(value) {

--- a/tests/__snapshots__/Calendar.spec.jsx.snap
+++ b/tests/__snapshots__/Calendar.spec.jsx.snap
@@ -173,7 +173,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell rc-calendar-last-month-cell"
                 role="gridcell"
-                title="2017-2-27"
+                title="2017年2月27日"
               >
                 <div
                   aria-disabled="false"
@@ -186,7 +186,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell rc-calendar-last-month-cell"
                 role="gridcell"
-                title="2017-2-28"
+                title="2017年2月28日"
               >
                 <div
                   aria-disabled="false"
@@ -199,7 +199,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-1"
+                title="2017年3月1日"
               >
                 <div
                   aria-disabled="false"
@@ -212,7 +212,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-2"
+                title="2017年3月2日"
               >
                 <div
                   aria-disabled="false"
@@ -225,7 +225,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-3"
+                title="2017年3月3日"
               >
                 <div
                   aria-disabled="false"
@@ -238,7 +238,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-4"
+                title="2017年3月4日"
               >
                 <div
                   aria-disabled="false"
@@ -251,7 +251,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-5"
+                title="2017年3月5日"
               >
                 <div
                   aria-disabled="false"
@@ -269,7 +269,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-6"
+                title="2017年3月6日"
               >
                 <div
                   aria-disabled="false"
@@ -282,7 +282,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-7"
+                title="2017年3月7日"
               >
                 <div
                   aria-disabled="false"
@@ -295,7 +295,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-8"
+                title="2017年3月8日"
               >
                 <div
                   aria-disabled="false"
@@ -308,7 +308,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-9"
+                title="2017年3月9日"
               >
                 <div
                   aria-disabled="false"
@@ -321,7 +321,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-10"
+                title="2017年3月10日"
               >
                 <div
                   aria-disabled="false"
@@ -334,7 +334,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-11"
+                title="2017年3月11日"
               >
                 <div
                   aria-disabled="false"
@@ -347,7 +347,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-12"
+                title="2017年3月12日"
               >
                 <div
                   aria-disabled="false"
@@ -365,7 +365,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-13"
+                title="2017年3月13日"
               >
                 <div
                   aria-disabled="false"
@@ -378,7 +378,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-14"
+                title="2017年3月14日"
               >
                 <div
                   aria-disabled="false"
@@ -391,7 +391,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-15"
+                title="2017年3月15日"
               >
                 <div
                   aria-disabled="false"
@@ -404,7 +404,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-16"
+                title="2017年3月16日"
               >
                 <div
                   aria-disabled="false"
@@ -417,7 +417,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-17"
+                title="2017年3月17日"
               >
                 <div
                   aria-disabled="false"
@@ -430,7 +430,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-18"
+                title="2017年3月18日"
               >
                 <div
                   aria-disabled="false"
@@ -443,7 +443,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-19"
+                title="2017年3月19日"
               >
                 <div
                   aria-disabled="false"
@@ -461,7 +461,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-20"
+                title="2017年3月20日"
               >
                 <div
                   aria-disabled="false"
@@ -474,7 +474,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-21"
+                title="2017年3月21日"
               >
                 <div
                   aria-disabled="false"
@@ -487,7 +487,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-22"
+                title="2017年3月22日"
               >
                 <div
                   aria-disabled="false"
@@ -500,7 +500,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-23"
+                title="2017年3月23日"
               >
                 <div
                   aria-disabled="false"
@@ -513,7 +513,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-24"
+                title="2017年3月24日"
               >
                 <div
                   aria-disabled="false"
@@ -526,7 +526,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-25"
+                title="2017年3月25日"
               >
                 <div
                   aria-disabled="false"
@@ -539,7 +539,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-26"
+                title="2017年3月26日"
               >
                 <div
                   aria-disabled="false"
@@ -557,7 +557,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-27"
+                title="2017年3月27日"
               >
                 <div
                   aria-disabled="false"
@@ -570,7 +570,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-28"
+                title="2017年3月28日"
               >
                 <div
                   aria-disabled="false"
@@ -583,7 +583,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell rc-calendar-today rc-calendar-selected-day"
                 role="gridcell"
-                title="2017-3-29"
+                title="2017年3月29日"
               >
                 <div
                   aria-disabled="false"
@@ -596,7 +596,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-30"
+                title="2017年3月30日"
               >
                 <div
                   aria-disabled="false"
@@ -609,7 +609,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-31"
+                title="2017年3月31日"
               >
                 <div
                   aria-disabled="false"
@@ -622,7 +622,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell rc-calendar-next-month-btn-day"
                 role="gridcell"
-                title="2017-4-1"
+                title="2017年4月1日"
               >
                 <div
                   aria-disabled="false"
@@ -635,7 +635,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell rc-calendar-next-month-btn-day"
                 role="gridcell"
-                title="2017-4-2"
+                title="2017年4月2日"
               >
                 <div
                   aria-disabled="false"
@@ -653,7 +653,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell rc-calendar-next-month-btn-day"
                 role="gridcell"
-                title="2017-4-3"
+                title="2017年4月3日"
               >
                 <div
                   aria-disabled="false"
@@ -666,7 +666,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell rc-calendar-next-month-btn-day"
                 role="gridcell"
-                title="2017-4-4"
+                title="2017年4月4日"
               >
                 <div
                   aria-disabled="false"
@@ -679,7 +679,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell rc-calendar-next-month-btn-day"
                 role="gridcell"
-                title="2017-4-5"
+                title="2017年4月5日"
               >
                 <div
                   aria-disabled="false"
@@ -692,7 +692,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell rc-calendar-next-month-btn-day"
                 role="gridcell"
-                title="2017-4-6"
+                title="2017年4月6日"
               >
                 <div
                   aria-disabled="false"
@@ -705,7 +705,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell rc-calendar-next-month-btn-day"
                 role="gridcell"
-                title="2017-4-7"
+                title="2017年4月7日"
               >
                 <div
                   aria-disabled="false"
@@ -718,7 +718,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell rc-calendar-next-month-btn-day"
                 role="gridcell"
-                title="2017-4-8"
+                title="2017年4月8日"
               >
                 <div
                   aria-disabled="false"
@@ -731,7 +731,7 @@ exports[`Calendar render render correctly 1`] = `
               <td
                 class="rc-calendar-cell rc-calendar-next-month-btn-day"
                 role="gridcell"
-                title="2017-4-9"
+                title="2017年4月9日"
               >
                 <div
                   aria-disabled="false"
@@ -754,7 +754,7 @@ exports[`Calendar render render correctly 1`] = `
           <a
             class="rc-calendar-today-btn "
             role="button"
-            title="2017-3-29"
+            title="2017年3月29日"
           >
             今天
           </a>
@@ -938,7 +938,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell rc-calendar-last-month-cell"
                 role="gridcell"
-                title="2017-2-26"
+                title="02/26/2017"
               >
                 <div
                   aria-disabled="false"
@@ -951,7 +951,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell rc-calendar-last-month-cell"
                 role="gridcell"
-                title="2017-2-27"
+                title="02/27/2017"
               >
                 <div
                   aria-disabled="false"
@@ -964,7 +964,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell rc-calendar-last-month-cell"
                 role="gridcell"
-                title="2017-2-28"
+                title="02/28/2017"
               >
                 <div
                   aria-disabled="false"
@@ -977,7 +977,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-1"
+                title="03/01/2017"
               >
                 <div
                   aria-disabled="false"
@@ -990,7 +990,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-2"
+                title="03/02/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1003,7 +1003,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-3"
+                title="03/03/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1016,7 +1016,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-4"
+                title="03/04/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1034,7 +1034,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-5"
+                title="03/05/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1047,7 +1047,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-6"
+                title="03/06/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1060,7 +1060,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-7"
+                title="03/07/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1073,7 +1073,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-8"
+                title="03/08/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1086,7 +1086,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-9"
+                title="03/09/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1099,7 +1099,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-10"
+                title="03/10/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1112,7 +1112,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-11"
+                title="03/11/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1130,7 +1130,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-12"
+                title="03/12/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1143,7 +1143,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-13"
+                title="03/13/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1156,7 +1156,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-14"
+                title="03/14/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1169,7 +1169,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-15"
+                title="03/15/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1182,7 +1182,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-16"
+                title="03/16/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1195,7 +1195,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-17"
+                title="03/17/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1208,7 +1208,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-18"
+                title="03/18/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1226,7 +1226,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-19"
+                title="03/19/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1239,7 +1239,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-20"
+                title="03/20/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1252,7 +1252,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-21"
+                title="03/21/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1265,7 +1265,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-22"
+                title="03/22/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1278,7 +1278,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-23"
+                title="03/23/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1291,7 +1291,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-24"
+                title="03/24/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1304,7 +1304,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-25"
+                title="03/25/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1322,7 +1322,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-26"
+                title="03/26/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1335,7 +1335,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-27"
+                title="03/27/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1348,7 +1348,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-28"
+                title="03/28/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1361,7 +1361,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell rc-calendar-today rc-calendar-selected-day"
                 role="gridcell"
-                title="2017-3-29"
+                title="03/29/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1374,7 +1374,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-30"
+                title="03/30/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1387,7 +1387,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell"
                 role="gridcell"
-                title="2017-3-31"
+                title="03/31/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1400,7 +1400,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell rc-calendar-next-month-btn-day"
                 role="gridcell"
-                title="2017-4-1"
+                title="04/01/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1418,7 +1418,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell rc-calendar-next-month-btn-day"
                 role="gridcell"
-                title="2017-4-2"
+                title="04/02/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1431,7 +1431,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell rc-calendar-next-month-btn-day"
                 role="gridcell"
-                title="2017-4-3"
+                title="04/03/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1444,7 +1444,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell rc-calendar-next-month-btn-day"
                 role="gridcell"
-                title="2017-4-4"
+                title="04/04/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1457,7 +1457,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell rc-calendar-next-month-btn-day"
                 role="gridcell"
-                title="2017-4-5"
+                title="04/05/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1470,7 +1470,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell rc-calendar-next-month-btn-day"
                 role="gridcell"
-                title="2017-4-6"
+                title="04/06/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1483,7 +1483,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell rc-calendar-next-month-btn-day"
                 role="gridcell"
-                title="2017-4-7"
+                title="04/07/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1496,7 +1496,7 @@ exports[`Calendar render render correctly 2`] = `
               <td
                 class="rc-calendar-cell rc-calendar-next-month-btn-day"
                 role="gridcell"
-                title="2017-4-8"
+                title="04/08/2017"
               >
                 <div
                   aria-disabled="false"
@@ -1519,7 +1519,7 @@ exports[`Calendar render render correctly 2`] = `
           <a
             class="rc-calendar-today-btn "
             role="button"
-            title="2017-3-29"
+            title="03/29/2017"
           >
             Today
           </a>

--- a/tests/__snapshots__/RangeCalendar.spec.jsx.snap
+++ b/tests/__snapshots__/RangeCalendar.spec.jsx.snap
@@ -166,7 +166,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-last-month-cell"
                     role="gridcell"
-                    title="2017-2-26"
+                    title="02/26/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -179,7 +179,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-last-month-cell"
                     role="gridcell"
-                    title="2017-2-27"
+                    title="02/27/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -192,7 +192,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-last-month-cell"
                     role="gridcell"
-                    title="2017-2-28"
+                    title="02/28/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -205,7 +205,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-3-1"
+                    title="03/01/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -218,7 +218,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-3-2"
+                    title="03/02/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -231,7 +231,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-3-3"
+                    title="03/03/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -244,7 +244,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-3-4"
+                    title="03/04/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -262,7 +262,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-3-5"
+                    title="03/05/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -275,7 +275,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-3-6"
+                    title="03/06/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -288,7 +288,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-3-7"
+                    title="03/07/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -301,7 +301,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-3-8"
+                    title="03/08/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -314,7 +314,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-3-9"
+                    title="03/09/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -327,7 +327,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-3-10"
+                    title="03/10/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -340,7 +340,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-3-11"
+                    title="03/11/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -358,7 +358,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-3-12"
+                    title="03/12/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -371,7 +371,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-3-13"
+                    title="03/13/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -384,7 +384,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-3-14"
+                    title="03/14/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -397,7 +397,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-3-15"
+                    title="03/15/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -410,7 +410,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-3-16"
+                    title="03/16/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -423,7 +423,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-3-17"
+                    title="03/17/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -436,7 +436,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-3-18"
+                    title="03/18/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -454,7 +454,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-3-19"
+                    title="03/19/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -467,7 +467,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-3-20"
+                    title="03/20/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -480,7 +480,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-3-21"
+                    title="03/21/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -493,7 +493,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-3-22"
+                    title="03/22/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -506,7 +506,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-3-23"
+                    title="03/23/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -519,7 +519,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-3-24"
+                    title="03/24/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -532,7 +532,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-3-25"
+                    title="03/25/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -550,7 +550,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-3-26"
+                    title="03/26/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -563,7 +563,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-3-27"
+                    title="03/27/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -576,7 +576,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-3-28"
+                    title="03/28/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -589,7 +589,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-today rc-calendar-selected-date rc-calendar-selected-day"
                     role="gridcell"
-                    title="2017-3-29"
+                    title="03/29/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -602,7 +602,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-3-30"
+                    title="03/30/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -615,7 +615,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-3-31"
+                    title="03/31/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -628,7 +628,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-next-month-btn-day"
                     role="gridcell"
-                    title="2017-4-1"
+                    title="04/01/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -646,7 +646,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-next-month-btn-day"
                     role="gridcell"
-                    title="2017-4-2"
+                    title="04/02/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -659,7 +659,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-next-month-btn-day"
                     role="gridcell"
-                    title="2017-4-3"
+                    title="04/03/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -672,7 +672,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-next-month-btn-day"
                     role="gridcell"
-                    title="2017-4-4"
+                    title="04/04/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -685,7 +685,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-next-month-btn-day"
                     role="gridcell"
-                    title="2017-4-5"
+                    title="04/05/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -698,7 +698,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-next-month-btn-day"
                     role="gridcell"
-                    title="2017-4-6"
+                    title="04/06/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -711,7 +711,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-next-month-btn-day"
                     role="gridcell"
-                    title="2017-4-7"
+                    title="04/07/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -724,7 +724,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-next-month-btn-day"
                     role="gridcell"
-                    title="2017-4-8"
+                    title="04/08/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -898,7 +898,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-last-month-cell"
                     role="gridcell"
-                    title="2017-3-26"
+                    title="03/26/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -911,7 +911,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-last-month-cell"
                     role="gridcell"
-                    title="2017-3-27"
+                    title="03/27/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -924,7 +924,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-last-month-cell"
                     role="gridcell"
-                    title="2017-3-28"
+                    title="03/28/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -937,7 +937,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-today rc-calendar-selected-date rc-calendar-last-month-cell"
                     role="gridcell"
-                    title="2017-3-29"
+                    title="03/29/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -950,7 +950,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-last-month-cell"
                     role="gridcell"
-                    title="2017-3-30"
+                    title="03/30/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -963,7 +963,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-last-month-cell"
                     role="gridcell"
-                    title="2017-3-31"
+                    title="03/31/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -976,7 +976,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-4-1"
+                    title="04/01/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -994,7 +994,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-4-2"
+                    title="04/02/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1007,7 +1007,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-4-3"
+                    title="04/03/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1020,7 +1020,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-4-4"
+                    title="04/04/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1033,7 +1033,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-4-5"
+                    title="04/05/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1046,7 +1046,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-4-6"
+                    title="04/06/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1059,7 +1059,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-4-7"
+                    title="04/07/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1072,7 +1072,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-4-8"
+                    title="04/08/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1090,7 +1090,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-4-9"
+                    title="04/09/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1103,7 +1103,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-4-10"
+                    title="04/10/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1116,7 +1116,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-4-11"
+                    title="04/11/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1129,7 +1129,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-4-12"
+                    title="04/12/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1142,7 +1142,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-4-13"
+                    title="04/13/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1155,7 +1155,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-4-14"
+                    title="04/14/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1168,7 +1168,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-4-15"
+                    title="04/15/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1186,7 +1186,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-4-16"
+                    title="04/16/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1199,7 +1199,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-4-17"
+                    title="04/17/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1212,7 +1212,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-4-18"
+                    title="04/18/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1225,7 +1225,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-4-19"
+                    title="04/19/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1238,7 +1238,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-4-20"
+                    title="04/20/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1251,7 +1251,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-4-21"
+                    title="04/21/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1264,7 +1264,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-4-22"
+                    title="04/22/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1282,7 +1282,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-4-23"
+                    title="04/23/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1295,7 +1295,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-4-24"
+                    title="04/24/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1308,7 +1308,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-4-25"
+                    title="04/25/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1321,7 +1321,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-4-26"
+                    title="04/26/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1334,7 +1334,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-4-27"
+                    title="04/27/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1347,7 +1347,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-in-range-cell"
                     role="gridcell"
-                    title="2017-4-28"
+                    title="04/28/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1360,7 +1360,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-selected-day"
                     role="gridcell"
-                    title="2017-4-29"
+                    title="04/29/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1378,7 +1378,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell"
                     role="gridcell"
-                    title="2017-4-30"
+                    title="04/30/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1391,7 +1391,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-next-month-btn-day"
                     role="gridcell"
-                    title="2017-5-1"
+                    title="05/01/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1404,7 +1404,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-next-month-btn-day"
                     role="gridcell"
-                    title="2017-5-2"
+                    title="05/02/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1417,7 +1417,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-next-month-btn-day"
                     role="gridcell"
-                    title="2017-5-3"
+                    title="05/03/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1430,7 +1430,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-next-month-btn-day"
                     role="gridcell"
-                    title="2017-5-4"
+                    title="05/04/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1443,7 +1443,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-next-month-btn-day"
                     role="gridcell"
-                    title="2017-5-5"
+                    title="05/05/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1456,7 +1456,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
                   <td
                     class="rc-calendar-cell rc-calendar-next-month-btn-day"
                     role="gridcell"
-                    title="2017-5-6"
+                    title="05/06/2017"
                   >
                     <div
                       aria-disabled="false"
@@ -1482,7 +1482,7 @@ exports[`RangeCalendar render hoverValue correctly 1`] = `
         <a
           class="rc-calendar-today-btn rc-calendar-today-btn-disabled"
           role="button"
-          title="2017-3-29"
+          title="03/29/2017"
         >
           Back to today
         </a>


### PR DESCRIPTION
This changes the way the title strings for day cells are generated - from hardcoded format to moment formatting (depending on currently set locale).

Resolves: https://github.com/react-component/calendar/issues/222