### PR TITLE
Allow setting custom format for date cell title (appears on hovering a date)

### DIFF
--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -207,7 +207,7 @@ const Calendar = createReactClass({
     const {
       locale, prefixCls, disabledDate,
       dateInputPlaceholder, timePicker,
-      disabledTime,
+      disabledTime, dateTitleFormat,
     } = props;
     const state = this.state;
     const { value, selectedValue, showTimePicker } = state;
@@ -263,6 +263,7 @@ const Calendar = createReactClass({
             : null}
           <div className={`${prefixCls}-body`}>
             <DateTable
+              dateTitleFormat={dateTitleFormat}
               locale={locale}
               value={value}
               selectedValue={selectedValue}

--- a/src/FullCalendar.jsx
+++ b/src/FullCalendar.jsx
@@ -9,6 +9,7 @@ import CalendarHeader from './full-calendar/CalendarHeader';
 
 const FullCalendar = createReactClass({
   propTypes: {
+    dateTitleFormat: PropTypes.string,
     defaultType: PropTypes.string,
     type: PropTypes.string,
     prefixCls: PropTypes.string,
@@ -77,6 +78,7 @@ const FullCalendar = createReactClass({
       headerComponent,
       headerRender,
       disabledDate,
+      dateTitleFormat,
     } = props;
     const { value, type } = this.state;
 
@@ -109,6 +111,7 @@ const FullCalendar = createReactClass({
         onSelect={this.onSelect}
         value={value}
         disabledDate={disabledDate}
+        dateTitleFormat={dateTitleFormat}
       />
     ) : (
       <MonthTable

--- a/src/date/DateTBody.jsx
+++ b/src/date/DateTBody.jsx
@@ -3,7 +3,7 @@ import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import DateConstants from './DateConstants';
-import { getTitleString, getTodayTime } from '../util/';
+import { getTodayTime } from '../util/';
 
 function isSameDay(one, two) {
   return one && two && one.isSame(two, 'day');
@@ -33,6 +33,7 @@ const DateTBody = createReactClass({
   propTypes: {
     contentRender: PropTypes.func,
     dateRender: PropTypes.func,
+    dateTitleFormat: PropTypes.string,
     disabledDate: PropTypes.func,
     prefixCls: PropTypes.string,
     selectedValue: PropTypes.oneOfType([PropTypes.object, PropTypes.arrayOf(PropTypes.object)]),
@@ -43,6 +44,7 @@ const DateTBody = createReactClass({
 
   getDefaultProps() {
     return {
+      dateTitleFormat: 'L',
       hoverValue: [],
     };
   },
@@ -52,7 +54,7 @@ const DateTBody = createReactClass({
     const {
       contentRender, prefixCls, selectedValue, value,
       showWeekNumber, dateRender, disabledDate,
-      hoverValue,
+      hoverValue, dateTitleFormat,
     } = props;
     let iIndex;
     let jIndex;
@@ -214,7 +216,7 @@ const DateTBody = createReactClass({
             onMouseEnter={disabled ?
               undefined : props.onDayHover && props.onDayHover.bind(null, current) || undefined}
             role="gridcell"
-            title={getTitleString(current)} className={cls}
+            title={current.format(dateTitleFormat)} className={cls}
           >
             {dateHtml}
           </td>);

--- a/src/range-calendar/CalendarPart.js
+++ b/src/range-calendar/CalendarPart.js
@@ -24,6 +24,7 @@ const CalendarPart = createReactClass({
     timePickerDisabledTime: PropTypes.object,
     enableNext: PropTypes.any,
     enablePrev: PropTypes.any,
+    dateTitleFormat: PropTypes.string,
   },
   render() {
     const props = this.props;
@@ -33,7 +34,7 @@ const CalendarPart = createReactClass({
       hoverValue,
       selectedValue,
       direction,
-      locale, format, placeholder,
+      dateTitleFormat, locale, format, placeholder,
       disabledDate, timePicker, disabledTime,
       timePickerDisabledTime, showTimePicker,
       onInputSelect, enablePrev, enableNext,
@@ -93,6 +94,7 @@ const CalendarPart = createReactClass({
           <div className={`${prefixCls}-body`}>
             <DateTable
               {...newProps}
+              dateTitleFormat={dateTitleFormat}
               hoverValue={hoverValue}
               selectedValue={selectedValue}
               dateRender={props.dateRender}

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -18,13 +18,9 @@ export function getTodayTime(value) {
   return today;
 }
 
-export function getTitleString(value) {
-  return value.format('L');
-}
-
 export function getTodayTimeStr(value) {
   const today = getTodayTime(value);
-  return getTitleString(today);
+  return today.format('L');
 }
 
 export function getMonthName(month) {


### PR DESCRIPTION
This allows setting a custom format string for the date titles, which appear on hover.

Before these changes, `L` would always be used. With these changes, you can pass a `dateTitlteFormat` prop to the relevant components with your custom date format string. For example:

```js
<DateTable
  dateTitleFormat="LL"
  disabledDate={(checkDate) => !isDateAllowed(checkDate)}
  locale={enUS}
  onSelect={(selectedMoment) => onDateSelect(selectedMoment)}
  prefixCls={calendarMonthClassName}
  selectedValue={selectedDate}
  value={value}
/>
```

Before:
<img width="107" alt="captura de pantalla 2017-06-12 a les 10 04 03" src="https://user-images.githubusercontent.com/98786/27045937-7b34c8a2-4f57-11e7-8d1f-a43c2126c82d.png">

After:
<img width="137" alt="captura de pantalla 2017-06-12 a les 10 03 31" src="https://user-images.githubusercontent.com/98786/27045945-80b94d48-4f57-11e7-8f79-7339e0e54de0.png">

We would like to have this functionality (implemented like this or in other ways) available in a release. I'd appreciate feedback, questions and suggestions.