### PR TITLE
update react refs to use callback instead of strings

### DIFF
--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -202,6 +202,9 @@ const Calendar = createReactClass({
       showTimePicker: false,
     });
   },
+  saveDateInput(dateInput) {
+    this.dateInputInstance = dateInput;
+  },
   render() {
     const props = this.props;
     const {
@@ -227,7 +230,7 @@ const Calendar = createReactClass({
     }) : null;
     const dateInputElement = props.showDateInput ? (
       <DateInput
-        ref="dateInput"
+        ref={this.saveDateInput}
         format={this.getFormat()}
         key="date-input"
         value={value}

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -202,9 +202,6 @@ const Calendar = createReactClass({
       showTimePicker: false,
     });
   },
-  saveDateInput(dateInput) {
-    this.dateInputInstance = dateInput;
-  },
   render() {
     const props = this.props;
     const {
@@ -230,7 +227,6 @@ const Calendar = createReactClass({
     }) : null;
     const dateInputElement = props.showDateInput ? (
       <DateInput
-        ref={this.saveDateInput}
         format={this.getFormat()}
         key="date-input"
         value={value}

--- a/src/RangeCalendar.js
+++ b/src/RangeCalendar.js
@@ -413,10 +413,6 @@ const RangeCalendar = createReactClass({
     return month.isSameOrBefore(value[0], 'month');
   },
 
-  saveRoot(root) {
-    this.rootInstance = root;
-  },
-
   render() {
     const props = this.props;
     const state = this.state;

--- a/src/RangeCalendar.js
+++ b/src/RangeCalendar.js
@@ -413,6 +413,10 @@ const RangeCalendar = createReactClass({
     return month.isSameOrBefore(value[0], 'month');
   },
 
+  saveRoot(root) {
+    this.rootInstance = root;
+  },
+
   render() {
     const props = this.props;
     const state = this.state;
@@ -473,7 +477,7 @@ const RangeCalendar = createReactClass({
             nextMonthOfStart.month() === endValue.month();
     return (
       <div
-        ref="root"
+        ref={this.saveRoot}
         className={classes}
         style={props.style}
         tabIndex="0"

--- a/src/date/DateInput.js
+++ b/src/date/DateInput.js
@@ -96,7 +96,13 @@ const DateInput = createReactClass({
   },
 
   focus() {
-    this.refs.dateInput.focus();
+    if (this.dateInputInstance) {
+      this.dateInputInstance.focus();
+    }
+  },
+
+  saveDateInput(dateInput) {
+    this.dateInputInstance = dateInput;
   },
 
   render() {
@@ -107,7 +113,7 @@ const DateInput = createReactClass({
     return (<div className={`${prefixCls}-input-wrap`}>
       <div className={`${prefixCls}-date-input-wrap`}>
         <input
-          ref="dateInput"
+          ref={this.saveDateInput}
           className={`${prefixCls}-input ${invalidClass}`}
           value={str}
           disabled={props.disabled}

--- a/src/mixin/CalendarMixin.js
+++ b/src/mixin/CalendarMixin.js
@@ -66,10 +66,6 @@ const CalendarMixin = {
     this.setSelectedValue(value, cause);
   },
 
-  saveRoot(root) {
-    this.rootInstance = root;
-  },
-
   renderRoot(newProps) {
     const props = this.props;
     const prefixCls = props.prefixCls;

--- a/src/mixin/CalendarMixin.js
+++ b/src/mixin/CalendarMixin.js
@@ -66,6 +66,10 @@ const CalendarMixin = {
     this.setSelectedValue(value, cause);
   },
 
+  saveRoot(root) {
+    this.rootInstance = root;
+  },
+
   renderRoot(newProps) {
     const props = this.props;
     const prefixCls = props.prefixCls;
@@ -79,7 +83,7 @@ const CalendarMixin = {
 
     return (
       <div
-        ref="root"
+        ref={this.saveRoot}
         className={`${classnames(className)}`}
         style={this.props.style}
         tabIndex="0"

--- a/src/mixin/CommonMixin.js
+++ b/src/mixin/CommonMixin.js
@@ -53,8 +53,8 @@ export default {
   },
 
   focus() {
-    if (this.refs.root) {
-      this.refs.root.focus();
+    if (this.rootInstance) {
+      this.rootInstance.focus();
     }
   },
 };

--- a/src/mixin/CommonMixin.js
+++ b/src/mixin/CommonMixin.js
@@ -57,4 +57,8 @@ export default {
       this.rootInstance.focus();
     }
   },
+
+  saveRoot(root) {
+    this.rootInstance = root;
+  },
 };


### PR DESCRIPTION
As of React v16 using strings to create refs will no longer work. This is is forward looking change to address future compatibility issues as well as fixing existing deprecation warning thrown by react v15.

For more info on refs, see https://facebook.github.io/react/docs/refs-and-the-dom.html