### PR TITLE
Compatible with React 0.14

### DIFF
--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -224,17 +224,27 @@ const Calendar = createReactClass({
     const disabledTimeConfig = showTimePicker && disabledTime && timePicker ?
       getTimeConfig(selectedValue, disabledTime) : null;
 
-    const timePickerEle = timePicker && showTimePicker ? React.cloneElement(timePicker, {
-      showHour: true,
-      showSecond: true,
-      showMinute: true,
-      ...timePicker.props,
-      ...disabledTimeConfig,
-      onChange: this.onDateInputChange,
-      defaultOpenValue: timePicker.props.defaultValue,
-      value: selectedValue,
-      disabledTime,
-    }) : null;
+    let timePickerEle = null;
+
+    if (timePicker && showTimePicker) {
+      const timePickerProps = {
+        showHour: true,
+        showSecond: true,
+        showMinute: true,
+        ...timePicker.props,
+        ...disabledTimeConfig,
+        onChange: this.onDateInputChange,
+        value: selectedValue,
+        disabledTime,
+      };
+
+      if (timePicker.props.defaultValue !== undefined) {
+        timePickerProps.defaultOpenValue = timePicker.props.defaultValue;
+      }
+
+      timePickerEle = React.cloneElement(timePicker, timePickerProps);
+    }
+
     const dateInputElement = props.showDateInput ? (
       <DateInput
         format={this.getFormat()}


### PR DESCRIPTION
React 0.14 pass undefined prop to the original element props, for example:

```javascript
element.props = { foo: 'bar' }

newElement = React.cloneElement(element, { foo: undefined })

newElement.props // React 0.14 { foo: undefined }, React 15 { foo: 'bar' }
```

Ref https://github.com/facebook/react/commit/48ded230fca7983dafeb310b8bf5f6ec96958b3d