### PR TITLE
Add showClear option to Calendar component

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,12 @@ http://react-component.github.io/calendar/examples/index.html
           <td>whether has ok button in footer</td>
         </tr>
         <tr>
+          <td>showClear</td>
+          <td>Boolean</td>
+          <td>true</td>
+          <td>whether has clear button in DateInput</td>
+        </tr>
+        <tr>
           <td>timePicker</td>
           <td>React Element</td>
           <td></td>

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -74,6 +74,7 @@ const Calendar = createReactClass({
     disabledTime: PropTypes.any,
     renderFooter: PropTypes.func,
     renderSidebar: PropTypes.func,
+    showClear: PropTypes.bool,
   },
 
   mixins: [CommonMixin, CalendarMixin],
@@ -82,6 +83,7 @@ const Calendar = createReactClass({
     return {
       showToday: true,
       showDateInput: true,
+      showClear: true,
       timePicker: null,
       onOk: noop,
       onPanelChange: noop,
@@ -217,7 +219,7 @@ const Calendar = createReactClass({
     const {
       locale, prefixCls, disabledDate,
       dateInputPlaceholder, timePicker,
-      disabledTime,
+      disabledTime, showClear,
     } = props;
     const { value, selectedValue, mode } = state;
     const showTimePicker = mode === 'time';
@@ -252,7 +254,7 @@ const Calendar = createReactClass({
         value={value}
         locale={locale}
         placeholder={dateInputPlaceholder}
-        showClear
+        showClear={showClear}
         disabledTime={disabledTime}
         disabledDate={disabledDate}
         onClear={this.onClear}


### PR DESCRIPTION
`Calendar` already implement this feature, but did't export it.
Because inner showClear prop is true by default, so I set default value to true.

**Please note `RangeCalendar` also has showClear and default value is false.**

trace:  #345 