### PR TITLE
 FR locale correction for "dateSelect"

### DIFF
--- a/src/locale/fr_FR.js
+++ b/src/locale/fr_FR.js
@@ -7,7 +7,7 @@ export default {
   month: 'Mois',
   year: 'Année',
   timeSelect: 'Sélectionner l\'heure',
-  dateSelect: 'Sélectionner l\'heure',
+  dateSelect: 'Sélectionner la date',
   monthSelect: 'Choisissez un mois',
   yearSelect: 'Choisissez une année',
   decadeSelect: 'Choisissez une décennie',


### PR DESCRIPTION
Change fr locale for "dateSelect" from 'Sélectionner l\'heure' to 'Sélectionner la date'