### PR TITLE
feat: add a prop to allow users to change the separator between range values

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,12 @@ http://react-component.github.io/calendar/examples/index.html
           <td>prefixCls of this component</td>
         </tr>
         <tr>
+          <td>separator</td>
+          <td>String</td>
+          <td>~</td>
+          <td>the text rendered between two range values</td>
+        </tr>
+        <tr>
           <td>className</td>
           <td>String</td>
           <td></td>

--- a/src/RangeCalendar.js
+++ b/src/RangeCalendar.js
@@ -75,6 +75,7 @@ function onInputSelect(direction, value) {
 const RangeCalendar = createReactClass({
   propTypes: {
     prefixCls: PropTypes.string,
+    separator: PropTypes.string,
     dateInputPlaceholder: PropTypes.any,
     defaultValue: PropTypes.any,
     value: PropTypes.any,
@@ -107,6 +108,7 @@ const RangeCalendar = createReactClass({
   getDefaultProps() {
     return {
       type: 'both',
+      separator: '~',
       defaultSelectedValue: [],
       onValueChange: noop,
       onHoverChange: noop,
@@ -595,7 +597,7 @@ const RangeCalendar = createReactClass({
     const {
       prefixCls, dateInputPlaceholder,
       timePicker, showOk, locale, showClear,
-      showToday, type, clearIcon,
+      showToday, type, clearIcon, separator,
     } = props;
     const {
       hoverValue,
@@ -699,7 +701,7 @@ const RangeCalendar = createReactClass({
               enableNext={!isClosestMonths || this.isMonthYearPanelShow(mode[1])}
               clearIcon={clearIcon}
             />
-            <span className={`${prefixCls}-range-middle`}>~</span>
+            <span className={`${prefixCls}-range-middle`}>{separator}</span>
             <CalendarPart
               {...props}
               {...newProps}


### PR DESCRIPTION
This is necessary to support the [proposed feature](https://github.com/ant-design/ant-design/issues/9891) in the ant.design `RangePicker` component.  

Allowing the separator to be changed via a prop will enable values such as "to" and foreign language equivalents.