### PR TITLE
trigger select when ENTER in input with valid value

### DIFF
--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -259,6 +259,7 @@ const Calendar = createReactClass({
         prefixCls={prefixCls}
         selectedValue={selectedValue}
         onChange={this.onDateInputChange}
+        onSelect={this.onSelect}
       />
     ) : null;
     const children = [

--- a/tests/Calendar.spec.jsx
+++ b/tests/Calendar.spec.jsx
@@ -482,6 +482,36 @@ describe('Calendar', () => {
       expect(onSelect.mock.calls[0][0].format(format)).toBe(expected);
       expect(onChange.mock.calls[0][0].format(format)).toBe(expected);
     });
+
+    it('keydown Enter will fire onSelect with valid value', () => {
+      const valid = '2017-01-01';
+      const onSelect = jest.fn();
+
+      const calendar = mount(<Calendar
+        format={format}
+        onSelect={onSelect}
+      />);
+      const input = calendar.find('.rc-calendar-input').hostNodes().at(0);
+      input.simulate('change', { target: { value: valid } });
+      input.simulate('keyDown', { keyCode: keyCode.ENTER });
+
+      expect(onSelect).toHaveBeenCalled();
+    });
+
+    it('keydown Enter will not fire onSelect with invalid value', () => {
+      const invalid = '2017-0';
+      const onSelect = jest.fn();
+
+      const calendar = mount(<Calendar
+        format={format}
+        showToday
+        onSelect={onSelect}
+      />);
+      const input = calendar.find('.rc-calendar-input').hostNodes().at(0);
+      input.simulate('change', { target: { value: invalid } });
+      input.simulate('keyDown', { keyCode: keyCode.ENTER });
+      expect(onSelect).not.toHaveBeenCalled();
+    });
   });
 
   it('handle clear', () => {


### PR DESCRIPTION
To fix https://github.com/ant-design/ant-design/issues/7474 ,

1. Add keydown handler to  'ENTER' key, fire onSelect if current input value is valid and not disabled. Not using '!this.state.invalid' as it consider empty string ('') to be valid input before.
2. Cleanup, extract a getInputValue function for reuse from onInputChange.
