### PR TITLE
feat: disable months in the past

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,12 @@ http://react-component.github.io/calendar/examples/index.html
           <td></td>
           <td>called when panel changed</td>
         </tr>
+        <tr>
+          <td>disableMonthsInPast</td>
+          <td>Boolean</td>
+          <td>false</td>
+          <td>whether to disable the year and month arrows on the left that link to dates in the past</td>
+        </tr>
     </tbody>
 </table>
 

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import KeyCode from 'rc-util/lib/KeyCode';
+import moment from 'moment';
 import DateTable from './date/DateTable';
 import CalendarHeader from './calendar/CalendarHeader';
 import CalendarFooter from './calendar/CalendarFooter';
@@ -218,6 +219,7 @@ const Calendar = createReactClass({
       locale, prefixCls, disabledDate,
       dateInputPlaceholder, timePicker,
       disabledTime,
+      disableMonthsInPast,
     } = props;
     const { value, selectedValue, mode } = state;
     const showTimePicker = mode === 'time';
@@ -244,6 +246,9 @@ const Calendar = createReactClass({
 
       timePickerEle = React.cloneElement(timePicker, timePickerProps);
     }
+
+    const disablePreviousMonth = disableMonthsInPast && value.clone().startOf('month').valueOf() <= moment().startOf('month').valueOf();
+    const disablePreviousYear = disableMonthsInPast && value.clone().startOf('year').valueOf() <= moment().startOf('year').valueOf();
 
     const dateInputElement = props.showDateInput ? (
       <DateInput
@@ -274,6 +279,8 @@ const Calendar = createReactClass({
             onPanelChange={this.onPanelChange}
             showTimePicker={showTimePicker}
             prefixCls={prefixCls}
+            disablePreviousMonth={disablePreviousMonth}
+            disablePreviousYear={disablePreviousYear}
           />
           {timePicker && showTimePicker ?
             (<div className={`${prefixCls}-time-picker`}>

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -247,8 +247,15 @@ const Calendar = createReactClass({
       timePickerEle = React.cloneElement(timePicker, timePickerProps);
     }
 
-    const disablePreviousMonth = disableMonthsInPast && value.clone().startOf('month').valueOf() <= moment().startOf('month').valueOf();
-    const disablePreviousYear = disableMonthsInPast && value.clone().startOf('year').valueOf() <= moment().startOf('year').valueOf();
+    const disablePreviousMonth = (
+      disableMonthsInPast &&
+      value.clone().startOf('month').valueOf() <= moment().startOf('month').valueOf()
+    );
+
+    const disablePreviousYear = (
+      disableMonthsInPast &&
+      value.clone().startOf('year').valueOf() <= moment().startOf('year').valueOf()
+    );
 
     const dateInputElement = props.showDateInput ? (
       <DateInput

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -75,6 +75,7 @@ const Calendar = createReactClass({
     disabledTime: PropTypes.any,
     renderFooter: PropTypes.func,
     renderSidebar: PropTypes.func,
+    disableMonthsInPast: PropTypes.bool,
   },
 
   mixins: [CommonMixin, CalendarMixin],

--- a/src/calendar/CalendarHeader.jsx
+++ b/src/calendar/CalendarHeader.jsx
@@ -142,6 +142,8 @@ const CalendarHeader = createReactClass({
       enableNext,
       enablePrev,
       disabledMonth,
+      disablePreviousMonth,
+      disablePreviousYear,
     } = props;
 
     let panel = null;
@@ -184,19 +186,29 @@ const CalendarHeader = createReactClass({
     return (<div className={`${prefixCls}-header`}>
       <div style={{ position: 'relative' }}>
         {showIf(enablePrev && !showTimePicker,
-          <a
-            className={`${prefixCls}-prev-year-btn`}
-            role="button"
-            onClick={this.previousYear}
-            title={locale.previousYear}
-          />)}
+          disablePreviousYear ? (
+            <span className={`${prefixCls}-prev-year-btn disabled`} />
+          ) : (
+            <a
+              className={`${prefixCls}-prev-year-btn`}
+              role="button"
+              onClick={this.previousYear}
+              title={locale.previousYear}
+            />
+          )
+        )}
         {showIf(enablePrev && !showTimePicker,
-          <a
-            className={`${prefixCls}-prev-month-btn`}
-            role="button"
-            onClick={this.previousMonth}
-            title={locale.previousMonth}
-          />)}
+          disablePreviousMonth ? (
+            <span className={`${prefixCls}-prev-month-btn disabled`} />
+          ) : (
+            <a
+              className={`${prefixCls}-prev-month-btn`}
+              role="button"
+              onClick={this.previousMonth}
+              title={locale.previousMonth}
+            />
+          )
+        )}
         {this.monthYearElement(showTimePicker)}
         {showIf(enableNext && !showTimePicker,
           <a

--- a/src/calendar/CalendarHeader.jsx
+++ b/src/calendar/CalendarHeader.jsx
@@ -33,6 +33,8 @@ const CalendarHeader = createReactClass({
     enablePrev: PropTypes.any,
     enableNext: PropTypes.any,
     disabledMonth: PropTypes.func,
+    disablePreviousMonth: PropTypes.bool,
+    disablePreviousYear: PropTypes.bool,
   },
 
   getDefaultProps() {

--- a/tests/Calendar.spec.jsx
+++ b/tests/Calendar.spec.jsx
@@ -28,6 +28,12 @@ describe('Calendar', () => {
       const wrapper = mount(<Calendar showToday={false}/>);
       expect(wrapper.find('.rc-calendar-today-btn').length).toBe(0);
     });
+
+    it('render disableMonthsInPast true correctly', () => {
+      const wrapper = mount(<Calendar disableMonthsInPast />);
+      expect(wrapper.find('.rc-calendar-prev-year-btn.disabled').length).toBe(1);
+      expect(wrapper.find('.rc-calendar-prev-month-btn.disabled').length).toBe(1);
+    });
   });
 
   describe('timePicker', () => {

--- a/tests/Calendar.spec.jsx
+++ b/tests/Calendar.spec.jsx
@@ -34,6 +34,12 @@ describe('Calendar', () => {
       expect(wrapper.find('.rc-calendar-prev-year-btn.disabled').length).toBe(1);
       expect(wrapper.find('.rc-calendar-prev-month-btn.disabled').length).toBe(1);
     });
+
+    it('render disableMonthsInPast false correctly', () => {
+      const wrapper = mount(<Calendar />);
+      expect(wrapper.find('.rc-calendar-prev-year-btn.disabled').length).toBe(0);
+      expect(wrapper.find('.rc-calendar-prev-month-btn.disabled').length).toBe(0);
+    });
   });
 
   describe('timePicker', () => {

--- a/tests/Calendar.spec.jsx
+++ b/tests/Calendar.spec.jsx
@@ -29,17 +29,19 @@ describe('Calendar', () => {
       expect(wrapper.find('.rc-calendar-today-btn').length).toBe(0);
     });
 
-    it('render disableMonthsInPast true correctly', () => {
-      const wrapper = mount(<Calendar disableMonthsInPast />);
-      expect(wrapper.find('.rc-calendar-prev-year-btn.disabled').length).toBe(1);
-      expect(wrapper.find('.rc-calendar-prev-month-btn.disabled').length).toBe(1);
-    });
+    describe('disableMonthsInPast', () => {
+      it('render disableMonthsInPast true correctly', () => {
+        const wrapper = mount(<Calendar disableMonthsInPast />);
+        expect(wrapper.find('.rc-calendar-prev-year-btn.disabled')).toHaveLength(1);
+        expect(wrapper.find('.rc-calendar-prev-month-btn.disabled')).toHaveLength(1);
+      });
 
-    it('render disableMonthsInPast false correctly', () => {
-      const wrapper = mount(<Calendar />);
-      expect(wrapper.find('.rc-calendar-prev-year-btn.disabled').length).toBe(0);
-      expect(wrapper.find('.rc-calendar-prev-month-btn.disabled').length).toBe(0);
-    });
+      it('render disableMonthsInPast false correctly', () => {
+        const wrapper = mount(<Calendar />);
+        expect(wrapper.find('.rc-calendar-prev-year-btn.disabled')).toHaveLength(0);
+        expect(wrapper.find('.rc-calendar-prev-month-btn.disabled')).toHaveLength(0);
+      });
+    })
   });
 
   describe('timePicker', () => {

--- a/tests/Calendar.spec.jsx
+++ b/tests/Calendar.spec.jsx
@@ -41,7 +41,7 @@ describe('Calendar', () => {
         expect(wrapper.find('.rc-calendar-prev-year-btn.disabled')).toHaveLength(0);
         expect(wrapper.find('.rc-calendar-prev-month-btn.disabled')).toHaveLength(0);
       });
-    })
+    });
   });
 
   describe('timePicker', () => {


### PR DESCRIPTION
We don't want the user to go to months in the past.

Here's a new prop `disableMonthsInPast`, that removes the links to dates in the past, and adds a `disabled` class, so the arrows can be styled as disabled (or can be hidden).