### PR TITLE
feat: use own icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,30 @@ http://react-component.github.io/calendar/examples/index.html
           <td></td>
           <td>called when panel changed</td>
         </tr>
+        <tr>
+          <td>prevMonthIcon</td>
+          <td>React.Node</td>
+          <td></td>
+          <td>to use an own arrow icon</td>
+        </tr>
+        <tr>
+          <td>nextMonthIcon</td>
+          <td>React.Node</td>
+          <td></td>
+          <td>to use an own arrow icon</td>
+        </tr>
+        <tr>
+          <td>prevYearIcon</td>
+          <td>React.Node</td>
+          <td></td>
+          <td>to use an own arrow icon</td>
+        </tr>
+        <tr>
+          <td>nextYearIcon</td>
+          <td>React.Node</td>
+          <td></td>
+          <td>to use an own arrow icon</td>
+        </tr>
     </tbody>
 </table>
 

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -218,6 +218,10 @@ const Calendar = createReactClass({
       locale, prefixCls, disabledDate,
       dateInputPlaceholder, timePicker,
       disabledTime,
+      prevMonthIcon,
+      nextMonthIcon,
+      prevYearIcon,
+      nextYearIcon,
     } = props;
     const { value, selectedValue, mode } = state;
     const showTimePicker = mode === 'time';
@@ -274,6 +278,10 @@ const Calendar = createReactClass({
             onPanelChange={this.onPanelChange}
             showTimePicker={showTimePicker}
             prefixCls={prefixCls}
+            prevMonthIcon={prevMonthIcon}
+            nextMonthIcon={nextMonthIcon}
+            prevYearIcon={prevYearIcon}
+            nextYearIcon={nextYearIcon}
           />
           {timePicker && showTimePicker ?
             (<div className={`${prefixCls}-time-picker`}>

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -74,6 +74,10 @@ const Calendar = createReactClass({
     disabledTime: PropTypes.any,
     renderFooter: PropTypes.func,
     renderSidebar: PropTypes.func,
+    prevMonthIcon: PropTypes.node,
+    nextMonthIcon: PropTypes.node,
+    prevYearIcon: PropTypes.node,
+    nextYearIcon: PropTypes.node,
   },
 
   mixins: [CommonMixin, CalendarMixin],

--- a/src/calendar/CalendarHeader.jsx
+++ b/src/calendar/CalendarHeader.jsx
@@ -33,6 +33,10 @@ const CalendarHeader = createReactClass({
     enablePrev: PropTypes.any,
     enableNext: PropTypes.any,
     disabledMonth: PropTypes.func,
+    prevMonthIcon: PropTypes.node,
+    nextMonthIcon: PropTypes.node,
+    prevYearIcon: PropTypes.node,
+    nextYearIcon: PropTypes.node,
   },
 
   getDefaultProps() {

--- a/src/calendar/CalendarHeader.jsx
+++ b/src/calendar/CalendarHeader.jsx
@@ -142,6 +142,10 @@ const CalendarHeader = createReactClass({
       enableNext,
       enablePrev,
       disabledMonth,
+      prevMonthIcon,
+      nextMonthIcon,
+      prevYearIcon,
+      nextYearIcon,
     } = props;
 
     let panel = null;
@@ -189,27 +193,39 @@ const CalendarHeader = createReactClass({
             role="button"
             onClick={this.previousYear}
             title={locale.previousYear}
-          />)}
+          >
+            {prevYearIcon}
+          </a>
+          )}
         {showIf(enablePrev && !showTimePicker,
           <a
             className={`${prefixCls}-prev-month-btn`}
             role="button"
             onClick={this.previousMonth}
             title={locale.previousMonth}
-          />)}
+          >
+            {prevMonthIcon}
+          </a>
+        )}
         {this.monthYearElement(showTimePicker)}
         {showIf(enableNext && !showTimePicker,
           <a
             className={`${prefixCls}-next-month-btn`}
             onClick={this.nextMonth}
             title={locale.nextMonth}
-          />)}
+          >
+            {nextMonthIcon}
+          </a>
+        )}
         {showIf(enableNext && !showTimePicker,
           <a
             className={`${prefixCls}-next-year-btn`}
             onClick={this.nextYear}
             title={locale.nextYear}
-          />)}
+          >
+            {nextYearIcon}
+          </a>
+        )}
       </div>
       {panel}
     </div>);

--- a/tests/Calendar.spec.jsx
+++ b/tests/Calendar.spec.jsx
@@ -28,6 +28,19 @@ describe('Calendar', () => {
       const wrapper = mount(<Calendar showToday={false}/>);
       expect(wrapper.find('.rc-calendar-today-btn').length).toBe(0);
     });
+
+    it('render correctly with own icons', () => {
+      const testIcon = <span className="test-icon" />;
+      const wrapper = mount(
+        <Calendar
+          prevMonthIcon={testIcon}
+          nextMonthIcon={testIcon}
+          prevYearIcon={testIcon}
+          nextYearIcon={testIcon}
+        />
+      );
+      expect(wrapper.find('.test-icon').length).toBe(4);
+    });
   });
 
   describe('timePicker', () => {


### PR DESCRIPTION
Here are some new props that make it possible to use our own icon elements for the arrows.

`prevMonthIcon`, `nextMonthIcon`, `prevYearIcon`, `nextYearIcon`