### PR TITLE
feat: make highlighting today optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,12 @@ http://react-component.github.io/calendar/examples/index.html
           <td></td>
           <td>called when panel changed</td>
         </tr>
+        <tr>
+          <td>highlightToday</td>
+          <td>Boolean</td>
+          <td>true</td>
+          <td>whether to highlight the current day</td>
+        </tr>
     </tbody>
 </table>
 

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -74,6 +74,7 @@ const Calendar = createReactClass({
     disabledTime: PropTypes.any,
     renderFooter: PropTypes.func,
     renderSidebar: PropTypes.func,
+    highlightToday: PropTypes.bool,
   },
 
   mixins: [CommonMixin, CalendarMixin],
@@ -85,6 +86,7 @@ const Calendar = createReactClass({
       timePicker: null,
       onOk: noop,
       onPanelChange: noop,
+      highlightToday: true,
     };
   },
   getInitialState() {
@@ -292,6 +294,7 @@ const Calendar = createReactClass({
               onSelect={this.onDateTableSelect}
               disabledDate={disabledDate}
               showWeekNumber={props.showWeekNumber}
+              highlightToday={props.highlightToday}
             />
           </div>
 

--- a/src/RangeCalendar.js
+++ b/src/RangeCalendar.js
@@ -97,6 +97,7 @@ const RangeCalendar = createReactClass({
     type: PropTypes.any,
     disabledDate: PropTypes.func,
     disabledTime: PropTypes.func,
+    highlightToday: PropTypes.bool,
   },
 
   mixins: [CommonMixin],
@@ -112,6 +113,7 @@ const RangeCalendar = createReactClass({
       onInputSelect: noop,
       showToday: true,
       showDateInput: true,
+      highlightToday: true,
     };
   },
 

--- a/src/date/DateTBody.jsx
+++ b/src/date/DateTBody.jsx
@@ -53,6 +53,7 @@ const DateTBody = createReactClass({
       contentRender, prefixCls, selectedValue, value,
       showWeekNumber, dateRender, disabledDate,
       hoverValue,
+      highlightToday,
     } = props;
     let iIndex;
     let jIndex;
@@ -126,7 +127,9 @@ const DateTBody = createReactClass({
         let selected = false;
 
         if (isSameDay(current, today)) {
-          cls += ` ${todayClass}`;
+          if (highlightToday) {
+            cls += ` ${todayClass}`;
+          }
           isCurrentWeek = true;
         }
 

--- a/src/range-calendar/CalendarPart.js
+++ b/src/range-calendar/CalendarPart.js
@@ -107,6 +107,7 @@ const CalendarPart = createReactClass({
               onDayHover={props.onDayHover}
               disabledDate={disabledDate}
               showWeekNumber={props.showWeekNumber}
+              highlightToday={props.highlightToday}
             />
           </div>
         </div>

--- a/tests/Calendar.spec.jsx
+++ b/tests/Calendar.spec.jsx
@@ -28,6 +28,16 @@ describe('Calendar', () => {
       const wrapper = mount(<Calendar showToday={false}/>);
       expect(wrapper.find('.rc-calendar-today-btn').length).toBe(0);
     });
+
+    it('render highlightToday true correctly', () => {
+      const wrapper = mount(<Calendar highlightToday />);
+      expect(wrapper.find('.rc-calendar-today')).toHaveLength(1);
+    });
+
+    it('render highlightToday false correctly', () => {
+      const wrapper = mount(<Calendar highlightToday={false} />);
+      expect(wrapper.find('.rc-calendar-today')).toHaveLength(0);
+    });
   });
 
   describe('timePicker', () => {


### PR DESCRIPTION
If you don't want the current day always to be highlighted, and don't want to overwrite a lot of ant-design styles, it is useful to just have a prop to disable it.