### PR TITLE
feat: add class to next month row

### DIFF
--- a/src/date/DateTBody.jsx
+++ b/src/date/DateTBody.jsx
@@ -70,6 +70,7 @@ const DateTBody = createReactClass({
     const inRangeClass = `${prefixCls}-in-range-cell`;
     const lastMonthDayClass = `${prefixCls}-last-month-cell`;
     const nextMonthDayClass = `${prefixCls}-next-month-btn-day`;
+    const nextMonthRowClass = `${prefixCls}-next-month-row`;
     const disabledClass = `${prefixCls}-disabled-cell`;
     const firstDisableClass = `${prefixCls}-disabled-cell-first-of-row`;
     const lastDisableClass = `${prefixCls}-disabled-cell-last-of-row`;
@@ -99,6 +100,7 @@ const DateTBody = createReactClass({
       let isCurrentWeek;
       let weekNumberCell;
       let isActiveWeek = false;
+      let isNextMonthRow = true;
       const dateCells = [];
       if (showWeekNumber) {
         weekNumberCell = (
@@ -169,8 +171,11 @@ const DateTBody = createReactClass({
         if (isBeforeCurrentMonthYear) {
           cls += ` ${lastMonthDayClass}`;
         }
+
         if (isAfterCurrentMonthYear) {
           cls += ` ${nextMonthDayClass}`;
+        } else {
+          isNextMonthRow = false;
         }
 
         if (disabledDate) {
@@ -234,6 +239,7 @@ const DateTBody = createReactClass({
           className={cx({
             [`${prefixCls}-current-week`]: isCurrentWeek,
             [`${prefixCls}-active-week`]: isActiveWeek,
+            [nextMonthRowClass]: isNextMonthRow,
           })}
         >
           {weekNumberCell}


### PR DESCRIPTION
When the last row in the calendar contains only days from the next month, it doesn't make sense to show that row.

For that I added a class `${prefixCls}-next-month-row` that can be styled to `display: none;` in the application, so the row is not displayed anymore.