### PR TITLE
feat: select multiple dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,24 @@ http://react-component.github.io/calendar/examples/index.html
           <td></td>
           <td>called when hover value change</td>
         </tr>
+        <tr>
+          <td>multiple</td>
+          <td>Boolean</td>
+          <td>false</td>
+          <td>make it possible to select multiple values</td>
+        </tr>
+        <tr>
+          <td>selectWeekDays</td>
+          <td>Boolean</td>
+          <td>false</td>
+          <td>make it possible to select all days of one weekday, e.g. all sundays</td>
+        </tr>
+        <tr>
+          <td>selectMonths</td>
+          <td>Boolean</td>
+          <td>false</td>
+          <td>make it possible to select an entire month</td>
+        </tr>
     </tbody>
 </table>
 

--- a/examples/antd-calendar-multi.html
+++ b/examples/antd-calendar-multi.html
@@ -1,0 +1,1 @@
+placeholder

--- a/examples/antd-calendar-multi.js
+++ b/examples/antd-calendar-multi.js
@@ -1,0 +1,80 @@
+/* eslint react/no-multi-comp:0, no-console:0 */
+
+import 'rc-calendar/assets/index.less';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Calendar from 'rc-calendar';
+import enUS from 'rc-calendar/src/locale/en_US';
+
+import moment from 'moment';
+import 'moment/locale/en-gb';
+
+const format = 'YYYY-MM-DD';
+
+const now = moment();
+now.locale('en-gb').utcOffset(0);
+
+const defaultCalendarValue = now.clone();
+defaultCalendarValue.add(-1, 'month');
+
+function disabledDate(current) {
+  if (!current) {
+    // allow empty select
+    return false;
+  }
+  const date = moment();
+  date.hour(0);
+  date.minute(0);
+  date.second(0);
+  return current.valueOf() < date.valueOf();  // can not select days before today
+}
+
+function formatStr(value, strFormat) {
+  let str;
+
+  str = value && value.length && value.map((singleValue) => {
+    return singleValue.format(strFormat) || '';
+  }).join(', ') || '';
+
+  return str;
+}
+
+function onStandaloneSelect(value) {
+  console.log('onStandaloneSelect', value);
+  console.log(formatStr(value, format));
+}
+
+function onStandaloneChange(value) {
+  console.log('onStandaloneChange', value);
+  console.log(formatStr(value, format));
+}
+
+
+ReactDOM.render((<div
+  style={{
+    zIndex: 1000,
+    position: 'relative',
+    width: 900,
+    margin: '20px auto',
+  }}
+>
+  <div>
+    <div style={{ margin: 10 }}>
+      <Calendar
+        showWeekNumber={false}
+        locale={enUS}
+        defaultValue={[now]}
+        showToday
+        formatter={format}
+        showOk={false}
+        onChange={onStandaloneChange}
+        disabledDate={disabledDate}
+        onSelect={onStandaloneSelect}
+        multiple
+        selectWeekDays
+        selectMonths
+      />
+    </div>
+    <div style={{ clear: 'both' }}></div>
+  </div>
+</div>), document.getElementById('__react-content'));

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -9,27 +9,28 @@ import CalendarFooter from './calendar/CalendarFooter';
 import CalendarMixin from './mixin/CalendarMixin';
 import CommonMixin from './mixin/CommonMixin';
 import DateInput from './date/DateInput';
+import DateConstants from './date/DateConstants';
 import { getTimeConfig, getTodayTime, syncTime } from './util';
 
 function noop() {
 }
 
 function goStartMonth() {
-  const next = this.state.value.clone();
+  const next = this.state.displayedValue.clone();
   next.startOf('month');
-  this.setValue(next);
+  this.setDisplayedValue(next);
 }
 
 function goEndMonth() {
-  const next = this.state.value.clone();
-  next.endOf('month');
-  this.setValue(next);
+  const next = this.state.displayedValue.clone();
+  next.startOf('month');
+  this.setDisplayedValue(next);
 }
 
 function goTime(direction, unit) {
-  const next = this.state.value.clone();
+  const next = this.state.displayedValue.clone();
   next.add(direction, unit);
-  this.setValue(next);
+  this.setDisplayedValue(next);
 }
 
 function goMonth(direction) {
@@ -53,9 +54,9 @@ const Calendar = createReactClass({
     prefixCls: PropTypes.string,
     className: PropTypes.string,
     style: PropTypes.object,
-    defaultValue: PropTypes.object,
-    value: PropTypes.object,
-    selectedValue: PropTypes.object,
+    defaultValue: PropTypes.oneOfType([PropTypes.object, PropTypes.arrayOf(PropTypes.object)]),
+    value: PropTypes.oneOfType([PropTypes.object, PropTypes.arrayOf(PropTypes.object)]),
+    selectedValue: PropTypes.oneOfType([PropTypes.object, PropTypes.arrayOf(PropTypes.object)]),
     mode: PropTypes.oneOf(['time', 'date', 'month', 'year', 'decade']),
     locale: PropTypes.object,
     showDateInput: PropTypes.bool,
@@ -74,6 +75,7 @@ const Calendar = createReactClass({
     disabledTime: PropTypes.any,
     renderFooter: PropTypes.func,
     renderSidebar: PropTypes.func,
+    multiple: PropTypes.bool,
   },
 
   mixins: [CommonMixin, CalendarMixin],
@@ -105,7 +107,7 @@ const Calendar = createReactClass({
     // mac
     const ctrlKey = event.ctrlKey || event.metaKey;
     const { disabledDate } = this.props;
-    const { value } = this.state;
+    const { displayedValue } = this.state;
     switch (keyCode) {
       case KeyCode.DOWN:
         goWeek.call(this, 1);
@@ -148,8 +150,8 @@ const Calendar = createReactClass({
         event.preventDefault();
         return 1;
       case KeyCode.ENTER:
-        if (!disabledDate || !disabledDate(value)) {
-          this.onSelect(value, {
+        if (!disabledDate || !disabledDate(displayedValue)) {
+          this.onSelect(displayedValue, {
             source: 'keyboard',
           });
         }
@@ -178,7 +180,7 @@ const Calendar = createReactClass({
       source: 'dateInput',
     });
   },
-  onDateTableSelect(value) {
+  onDateTableSelect(value, cause) {
     const { timePicker } = this.props;
     const { selectedValue } = this.state;
     if (!selectedValue && timePicker) {
@@ -187,12 +189,12 @@ const Calendar = createReactClass({
         syncTime(timePickerDefaultValue, value);
       }
     }
-    this.onSelect(value);
+    this.onSelect(value, cause);
   },
   onToday() {
-    const { value } = this.state;
-    const now = getTodayTime(value);
-    this.onSelect(now, {
+    const { displayedValue } = this.state;
+    const now = getTodayTime(displayedValue);
+    this.onDateTableSelect(now, {
       source: 'todayButton',
     });
   },
@@ -202,6 +204,102 @@ const Calendar = createReactClass({
       this.setState({ mode });
     }
     props.onPanelChange(value || state.value, mode);
+  },
+  onWeekDaysSelect({ month, weekday }) {
+    const days = this.getWeekdaysOfMonth({ month, weekday });
+
+    if (!days.length) return;
+
+    const allSelected = this.checkAllSelected(days);
+
+    let newValue = [];
+
+    if (allSelected) {
+      newValue = this.addOrRemoveMultipleValues({ remove: days });
+    } else {
+      newValue = this.addOrRemoveMultipleValues({ add: days });
+    }
+
+    this.setSelectedValue(newValue);
+  },
+  onWeekDaysMouseEnter({ month, weekday }) {
+    const days = this.getWeekdaysOfMonth({ month, weekday });
+
+    this.setState({ hoverValue: days });
+  },
+  onMonthMouseEnter(month) {
+    const days = this.getDaysOfMonth(month);
+
+    this.setState({ hoverValue: days });
+  },
+  onMouseLeave() {
+    this.setState({ hoverValue: null });
+  },
+  onMonthSelect(month) {
+    const days = this.getDaysOfMonth(month);
+
+    const allSelected = this.checkAllSelected(days);
+
+    let newValue = [];
+
+    if (allSelected) {
+      newValue = this.addOrRemoveMultipleValues({ remove: days });
+    } else {
+      newValue = this.addOrRemoveMultipleValues({ add: days });
+    }
+
+    this.setSelectedValue(newValue);
+  },
+  getWeekdaysOfMonth({ month, weekday }) {
+    const firstDayOfMonth = month.clone().startOf('month');
+    const lastDayOfMonth = month.clone().endOf('month');
+    const weekdayOfFirstDayOfMonth = firstDayOfMonth.day();
+    const offset = (
+      DateConstants.DATE_COL_COUNT + weekday - weekdayOfFirstDayOfMonth
+    ) % DateConstants.DATE_COL_COUNT;
+    const current = firstDayOfMonth.clone().add(offset, 'days');
+
+    const selectedDates = [];
+
+    do {
+      if (!this.props.disabledDate(current)) {
+        selectedDates.push(current.clone());
+      }
+    } while (current.add(7, 'days').isBefore(lastDayOfMonth));
+
+    return selectedDates;
+  },
+  getDaysOfMonth(month) {
+    const firstDayOfMonth = month.clone().startOf('month');
+    const lastDayOfMonth = month.clone().endOf('month');
+
+    const selectedDates = [];
+
+    const day = firstDayOfMonth;
+
+    while (day.isBefore(lastDayOfMonth)) {
+      if (!this.props.disabledDate(day)) {
+        selectedDates.push(day.clone());
+      }
+
+      day.add(1, 'day');
+    }
+
+    return selectedDates;
+  },
+  checkAllSelected(days) {
+    const originalValue = this.state.selectedValue || [];
+    const originalDayStrings = originalValue.map((day) => day.format('YYYYMMDD'));
+
+    let allSelected = true;
+    days.forEach((day) => {
+      const dayString = day.format('YYYYMMDD');
+      if (!originalDayStrings.includes(dayString)) {
+        allSelected = false;
+      }
+    });
+
+    return allSelected;
   },
   getRootDOMNode() {
     return ReactDOM.findDOMNode(this);
@@ -218,8 +316,9 @@ const Calendar = createReactClass({
       locale, prefixCls, disabledDate,
       dateInputPlaceholder, timePicker,
       disabledTime,
+      multiple,
     } = props;
-    const { value, selectedValue, mode } = state;
+    const { value, selectedValue, displayedValue, hoverValue, mode } = state;
     const showTimePicker = mode === 'time';
     const disabledTimeConfig = showTimePicker && disabledTime && timePicker ?
       getTimeConfig(selectedValue, disabledTime) : null;
@@ -259,6 +358,7 @@ const Calendar = createReactClass({
         prefixCls={prefixCls}
         selectedValue={selectedValue}
         onChange={this.onDateInputChange}
+        multiple={multiple}
       />
     ) : null;
     const children = [
@@ -270,10 +370,16 @@ const Calendar = createReactClass({
             locale={locale}
             mode={mode}
             value={value}
+            displayedValue={displayedValue}
             onValueChange={this.setValue}
             onPanelChange={this.onPanelChange}
+            setDisplayedValue={this.setDisplayedValue}
             showTimePicker={showTimePicker}
             prefixCls={prefixCls}
+            multiple={multiple}
+            onMonthSelect={this.props.selectMonths && this.onMonthSelect}
+            onMonthMouseEnter={this.props.selectMonths && this.onMonthMouseEnter}
+            onMonthMouseLeave={this.props.selectMonths && this.onMouseLeave}
           />
           {timePicker && showTimePicker ?
             (<div className={`${prefixCls}-time-picker`}>
@@ -287,11 +393,17 @@ const Calendar = createReactClass({
               locale={locale}
               value={value}
               selectedValue={selectedValue}
+              displayedValue={displayedValue}
+              hoverValue={hoverValue}
               prefixCls={prefixCls}
               dateRender={props.dateRender}
               onSelect={this.onDateTableSelect}
               disabledDate={disabledDate}
               showWeekNumber={props.showWeekNumber}
+              multiple={multiple}
+              onWeekDaysSelect={this.props.selectWeekDays && this.onWeekDaysSelect}
+              onWeekDaysMouseEnter={this.props.selectWeekDays && this.onWeekDaysMouseEnter}
+              onWeekDaysMouseLeave={this.props.selectWeekDays && this.onMouseLeave}
             />
           </div>
 
@@ -307,13 +419,15 @@ const Calendar = createReactClass({
             timePicker={timePicker}
             selectedValue={selectedValue}
             value={value}
+            displayedValue={displayedValue}
             disabledDate={disabledDate}
-            okDisabled={!this.isAllowedDate(selectedValue)}
+            okDisabled={!this.isAllowedDate(selectedValue, multiple)}
             onOk={this.onOk}
-            onSelect={this.onSelect}
+            onSelect={this.onDateTableSelect}
             onToday={this.onToday}
             onOpenTimePicker={this.openTimePicker}
             onCloseTimePicker={this.closeTimePicker}
+            multiple={multiple}
           />
         </div>
       </div>),

--- a/src/FullCalendar.jsx
+++ b/src/FullCalendar.jsx
@@ -107,7 +107,7 @@ const FullCalendar = createReactClass({
         locale={locale}
         prefixCls={prefixCls}
         onSelect={this.onSelect}
-        value={value}
+        displayedValue={value}
         disabledDate={disabledDate}
       />
     ) : (

--- a/src/MonthCalendar.jsx
+++ b/src/MonthCalendar.jsx
@@ -21,20 +21,20 @@ const MonthCalendar = createReactClass({
   onKeyDown(event) {
     const keyCode = event.keyCode;
     const ctrlKey = event.ctrlKey || event.metaKey;
-    const stateValue = this.state.value;
     const { disabledDate } = this.props;
-    let value = stateValue;
+    const { displayedValue } = this.state;
+    let value = displayedValue;
     switch (keyCode) {
       case KeyCode.DOWN:
-        value = stateValue.clone();
+        value = displayedValue.clone();
         value.add(3, 'months');
         break;
       case KeyCode.UP:
-        value = stateValue.clone();
+        value = displayedValue.clone();
         value.add(-3, 'months');
         break;
       case KeyCode.LEFT:
-        value = stateValue.clone();
+        value = displayedValue.clone();
         if (ctrlKey) {
           value.add(-1, 'years');
         } else {
@@ -42,7 +42,7 @@ const MonthCalendar = createReactClass({
         }
         break;
       case KeyCode.RIGHT:
-        value = stateValue.clone();
+        value = displayedValue.clone();
         if (ctrlKey) {
           value.add(1, 'years');
         } else {
@@ -50,16 +50,16 @@ const MonthCalendar = createReactClass({
         }
         break;
       case KeyCode.ENTER:
-        if (!disabledDate || !disabledDate(stateValue)) {
-          this.onSelect(stateValue);
+        if (!disabledDate || !disabledDate(displayedValue)) {
+          this.onSelect(displayedValue);
         }
         event.preventDefault();
         return 1;
       default:
         return undefined;
     }
-    if (value !== stateValue) {
-      this.setValue(value);
+    if (value !== displayedValue) {
+      this.setDisplayedValue(value);
       event.preventDefault();
       return 1;
     }
@@ -73,7 +73,7 @@ const MonthCalendar = createReactClass({
 
   render() {
     const { props, state } = this;
-    const { mode, value } = state;
+    const { mode, value, displayedValue } = state;
     const children = (
       <div className={`${props.prefixCls}-month-calendar-content`}>
         <div className={`${props.prefixCls}-month-header-wrap`}>
@@ -81,6 +81,7 @@ const MonthCalendar = createReactClass({
             prefixCls={props.prefixCls}
             mode={mode}
             value={value}
+            displayedValue={displayedValue}
             locale={props.locale}
             disabledMonth={props.disabledDate}
             monthCellRender={props.monthCellRender}
@@ -88,6 +89,7 @@ const MonthCalendar = createReactClass({
             onMonthSelect={this.onSelect}
             onValueChange={this.setValue}
             onPanelChange={this.handlePanelChange}
+            setDisplayedValue={this.setDisplayedValue}
           />
         </div>
         <CalendarFooter

--- a/src/Picker.jsx
+++ b/src/Picker.jsx
@@ -108,9 +108,12 @@ const Picker = createReactClass({
       });
     }
     if (
-      cause.source === 'keyboard' ||
-      (!props.calendar.props.timePicker && cause.source !== 'dateInput') ||
-      cause.source === 'todayButton') {
+      !props.multiple && (
+        cause.source === 'keyboard' ||
+        (!props.calendar.props.timePicker && cause.source !== 'dateInput') ||
+        cause.source === 'todayButton'
+      )
+    ) {
       this.close(this.focus);
     }
     props.onChange(value);

--- a/src/RangeCalendar.js
+++ b/src/RangeCalendar.js
@@ -588,7 +588,7 @@ const RangeCalendar = createReactClass({
                   <TodayButton
                     {...props}
                     disabled={isTodayInView}
-                    value={state.value[0]}
+                    displayedValue={state.value[0]}
                     onToday={this.onToday}
                     text={locale.backToToday}
                   />

--- a/src/calendar/CalendarFooter.jsx
+++ b/src/calendar/CalendarFooter.jsx
@@ -14,12 +14,14 @@ const CalendarFooter = createReactClass({
     showDateInput: PropTypes.bool,
     disabledTime: PropTypes.any,
     timePicker: PropTypes.element,
-    selectedValue: PropTypes.any,
+    selectedValue: PropTypes.oneOfType([PropTypes.object, PropTypes.arrayOf(PropTypes.object)]),
     showOk: PropTypes.bool,
     onSelect: PropTypes.func,
-    value: PropTypes.object,
+    value: PropTypes.oneOfType([PropTypes.object, PropTypes.arrayOf(PropTypes.object)]),
+    displayedValue: PropTypes.object,
     renderFooter: PropTypes.func,
-    defaultValue: PropTypes.object,
+    defaultValue: PropTypes.oneOfType([PropTypes.object, PropTypes.arrayOf(PropTypes.object)]),
+    multiple: PropTypes.bool,
   },
 
   onSelect(value) {

--- a/src/calendar/CalendarHeader.jsx
+++ b/src/calendar/CalendarHeader.jsx
@@ -7,15 +7,15 @@ import YearPanel from '../year/YearPanel';
 import DecadePanel from '../decade/DecadePanel';
 
 function goMonth(direction) {
-  const next = this.props.value.clone();
+  const next = this.props.displayedValue.clone();
   next.add(direction, 'months');
-  this.props.onValueChange(next);
+  this.props.setDisplayedValue(next);
 }
 
 function goYear(direction) {
-  const next = this.props.value.clone();
+  const next = this.props.displayedValue.clone();
   next.add(direction, 'years');
-  this.props.onValueChange(next);
+  this.props.setDisplayedValue(next);
 }
 
 function showIf(condition, el) {
@@ -25,7 +25,8 @@ function showIf(condition, el) {
 const CalendarHeader = createReactClass({
   propTypes: {
     prefixCls: PropTypes.string,
-    value: PropTypes.object,
+    value: PropTypes.oneOfType([PropTypes.object, PropTypes.arrayOf(PropTypes.object)]),
+    displayedValue: PropTypes.object,
     onValueChange: PropTypes.func,
     showTimePicker: PropTypes.bool,
     onPanelChange: PropTypes.func,
@@ -33,6 +34,7 @@ const CalendarHeader = createReactClass({
     enablePrev: PropTypes.any,
     enableNext: PropTypes.any,
     disabledMonth: PropTypes.func,
+    multiple: PropTypes.bool,
   },
 
   getDefaultProps() {
@@ -57,7 +59,7 @@ const CalendarHeader = createReactClass({
     if (this.props.onMonthSelect) {
       this.props.onMonthSelect(value);
     } else {
-      this.props.onValueChange(value);
+      this.props.setDisplayedValue(value);
     }
   },
 
@@ -65,29 +67,47 @@ const CalendarHeader = createReactClass({
     const referer = this.state.yearPanelReferer;
     this.setState({ yearPanelReferer: null });
     this.props.onPanelChange(value, referer);
-    this.props.onValueChange(value);
+    this.props.setDisplayedValue(value);
   },
 
   onDecadeSelect(value) {
     this.props.onPanelChange(value, 'year');
-    this.props.onValueChange(value);
+    this.props.setDisplayedValue(value);
   },
 
   monthYearElement(showTimePicker) {
     const props = this.props;
     const prefixCls = props.prefixCls;
     const locale = props.locale;
-    const value = props.value;
-    const localeData = value.localeData();
+    const displayedValue = props.displayedValue;
+    const localeData = displayedValue.localeData();
     const monthBeforeYear = locale.monthBeforeYear;
     const selectClassName = `${prefixCls}-${monthBeforeYear ? 'my-select' : 'ym-select'}`;
+
+    if (props.onMonthSelect) {
+      return (
+        <a
+          className={`${prefixCls}-month-select`}
+          onClick={() => {
+            props.onMonthSelect(displayedValue);
+          }}
+          onMouseEnter={() => {
+            props.onMonthMouseEnter(displayedValue);
+          }}
+          onMouseLeave={props.onMonthMouseLeave}
+        >
+          {localeData.months(displayedValue)} {displayedValue.format(locale.yearFormat)}
+        </a>
+      );
+    }
+
     const year = (<a
       className={`${prefixCls}-year-select`}
       role="button"
       onClick={showTimePicker ? null : () => this.showYearPanel('date')}
       title={locale.yearSelect}
     >
-      {value.format(locale.yearFormat)}
+      {displayedValue.format(locale.yearFormat)}
     </a>);
     const month = (<a
       className={`${prefixCls}-month-select`}
@@ -95,7 +115,7 @@ const CalendarHeader = createReactClass({
       onClick={showTimePicker ? null : this.showMonthPanel}
       title={locale.monthSelect}
     >
-      {localeData.monthsShort(value)}
+      {localeData.monthsShort(displayedValue)}
     </a>);
     let day;
     if (showTimePicker) {
@@ -103,7 +123,7 @@ const CalendarHeader = createReactClass({
         className={`${prefixCls}-day-select`}
         role="button"
       >
-        {value.format(locale.dayFormat)}
+        {displayedValue.format(locale.dayFormat)}
       </a>);
     }
     let my = [];
@@ -112,9 +132,11 @@ const CalendarHeader = createReactClass({
     } else {
       my = [year, month, day];
     }
-    return (<span className={selectClassName}>
-    {toFragment(my)}
-    </span>);
+    return (
+      <span className={selectClassName}>
+        {toFragment(my)}
+      </span>
+    );
   },
 
   showMonthPanel() {
@@ -138,6 +160,7 @@ const CalendarHeader = createReactClass({
       locale,
       mode,
       value,
+      displayedValue,
       showTimePicker,
       enableNext,
       enablePrev,
@@ -150,12 +173,14 @@ const CalendarHeader = createReactClass({
         <MonthPanel
           locale={locale}
           defaultValue={value}
+          displayedValue={displayedValue}
           rootPrefixCls={prefixCls}
           onSelect={this.onMonthSelect}
           onYearPanelShow={() => this.showYearPanel('month')}
           disabledDate={disabledMonth}
           cellRender={props.monthCellRender}
           contentRender={props.monthCellContentRender}
+          setDisplayedValue={props.setDisplayedValue}
         />
       );
     }
@@ -164,9 +189,11 @@ const CalendarHeader = createReactClass({
         <YearPanel
           locale={locale}
           defaultValue={value}
+          displayedValue={displayedValue}
           rootPrefixCls={prefixCls}
           onSelect={this.onYearSelect}
           onDecadePanelShow={this.showDecadePanel}
+          setDisplayedValue={props.setDisplayedValue}
         />
       );
     }
@@ -175,8 +202,10 @@ const CalendarHeader = createReactClass({
         <DecadePanel
           locale={locale}
           defaultValue={value}
+          displayedValue={displayedValue}
           rootPrefixCls={prefixCls}
           onSelect={this.onDecadeSelect}
+          setDisplayedValue={props.setDisplayedValue}
         />
       );
     }

--- a/src/calendar/TodayButton.jsx
+++ b/src/calendar/TodayButton.jsx
@@ -4,7 +4,7 @@ import { getTodayTimeStr, getTodayTime, isAllowedDate } from '../util/';
 export default function TodayButton({
   prefixCls,
   locale,
-  value,
+  displayedValue,
   timePicker,
   disabled,
   disabledDate,
@@ -13,7 +13,7 @@ export default function TodayButton({
 }) {
   const localeNow = (!text && timePicker ? locale.now : text) || locale.today;
   const disabledToday =
-          disabledDate && !isAllowedDate(getTodayTime(value), disabledDate);
+          disabledDate && !isAllowedDate(getTodayTime(displayedValue), disabledDate);
   const isDisabled = disabledToday || disabled;
   const disabledTodayClass = isDisabled ?
           `${prefixCls}-today-btn-disabled` : '';
@@ -22,7 +22,7 @@ export default function TodayButton({
       className={`${prefixCls}-today-btn ${disabledTodayClass}`}
       role="button"
       onClick={isDisabled ? null : onToday}
-      title={getTodayTimeStr(value)}
+      title={getTodayTimeStr(displayedValue)}
     >
       {localeNow}
     </a>

--- a/src/date/DateInput.js
+++ b/src/date/DateInput.js
@@ -8,7 +8,7 @@ const DateInput = createReactClass({
   propTypes: {
     prefixCls: PropTypes.string,
     timePicker: PropTypes.object,
-    value: PropTypes.object,
+    value: PropTypes.oneOfType([PropTypes.object, PropTypes.arrayOf(PropTypes.object)]),
     disabledTime: PropTypes.any,
     format: PropTypes.string,
     locale: PropTypes.object,
@@ -17,13 +17,13 @@ const DateInput = createReactClass({
     onClear: PropTypes.func,
     placeholder: PropTypes.string,
     onSelect: PropTypes.func,
-    selectedValue: PropTypes.object,
+    selectedValue: PropTypes.oneOfType([PropTypes.object, PropTypes.arrayOf(PropTypes.object)]),
+    multiple: PropTypes.bool,
   },
 
   getInitialState() {
-    const selectedValue = this.props.selectedValue;
     return {
-      str: selectedValue && selectedValue.format(this.props.format) || '',
+      str: this.formatStr(this.props),
       invalid: false,
     };
   },
@@ -32,9 +32,8 @@ const DateInput = createReactClass({
     this.cachedSelectionStart = this.dateInputInstance.selectionStart;
     this.cachedSelectionEnd = this.dateInputInstance.selectionEnd;
     // when popup show, click body will call this, bug!
-    const selectedValue = nextProps.selectedValue;
     this.setState({
-      str: selectedValue && selectedValue.format(nextProps.format) || '',
+      str: this.formatStr(nextProps),
       invalid: false,
     });
   },
@@ -45,7 +44,29 @@ const DateInput = createReactClass({
     }
   },
 
+  formatStr(props) {
+    let str;
+
+    const {
+      selectedValue,
+      multiple,
+      format,
+    } = props;
+
+    if (multiple) {
+      str = selectedValue && selectedValue.length && selectedValue.map((singleValue) => {
+        return singleValue.format(format) || '';
+      }).join(', ') || '';
+    } else {
+      str = selectedValue && selectedValue.format(format) || '';
+    }
+
+    return str;
+  },
+
   onInputChange(event) {
+    if (this.props.multiple) return;
+
     const str = event.target.value;
     this.setState({
       str,

--- a/src/date/DateTBody.jsx
+++ b/src/date/DateTBody.jsx
@@ -36,9 +36,10 @@ const DateTBody = createReactClass({
     disabledDate: PropTypes.func,
     prefixCls: PropTypes.string,
     selectedValue: PropTypes.oneOfType([PropTypes.object, PropTypes.arrayOf(PropTypes.object)]),
-    value: PropTypes.object,
+    value: PropTypes.oneOfType([PropTypes.object, PropTypes.arrayOf(PropTypes.object)]),
     hoverValue: PropTypes.any,
     showWeekNumber: PropTypes.bool,
+    multiple: PropTypes.bool,
   },
 
   getDefaultProps() {
@@ -53,12 +54,14 @@ const DateTBody = createReactClass({
       contentRender, prefixCls, selectedValue, value,
       showWeekNumber, dateRender, disabledDate,
       hoverValue,
+      multiple,
+      displayedValue,
     } = props;
     let iIndex;
     let jIndex;
     let current;
     const dateTable = [];
-    const today = getTodayTime(value);
+    const today = getTodayTime(displayedValue);
     const cellClass = `${prefixCls}-cell`;
     const weekNumberCellClass = `${prefixCls}-week-number-cell`;
     const dateClass = `${prefixCls}-date`;
@@ -67,16 +70,17 @@ const DateTBody = createReactClass({
     const selectedDateClass = `${prefixCls}-selected-date`;  // do not move with mouse operation
     const selectedStartDateClass = `${prefixCls}-selected-start-date`;
     const selectedEndDateClass = `${prefixCls}-selected-end-date`;
+    const hoveredDateClass = `${prefixCls}-hovered-date`;
     const inRangeClass = `${prefixCls}-in-range-cell`;
     const lastMonthDayClass = `${prefixCls}-last-month-cell`;
     const nextMonthDayClass = `${prefixCls}-next-month-btn-day`;
     const disabledClass = `${prefixCls}-disabled-cell`;
     const firstDisableClass = `${prefixCls}-disabled-cell-first-of-row`;
     const lastDisableClass = `${prefixCls}-disabled-cell-last-of-row`;
-    const month1 = value.clone();
+    const month1 = displayedValue.clone();
     month1.date(1);
     const day = month1.day();
-    const lastMonthDiffDay = (day + 7 - value.localeData().firstDayOfWeek()) % 7;
+    const lastMonthDiffDay = (day + 7 - displayedValue.localeData().firstDayOfWeek()) % 7;
     // calculate last month
     const lastMonth1 = month1.clone();
     lastMonth1.add(0 - lastMonthDiffDay, 'days');
@@ -130,10 +134,30 @@ const DateTBody = createReactClass({
           isCurrentWeek = true;
         }
 
-        const isBeforeCurrentMonthYear = beforeCurrentMonthYear(current, value);
-        const isAfterCurrentMonthYear = afterCurrentMonthYear(current, value);
+        const isBeforeCurrentMonthYear = beforeCurrentMonthYear(current, displayedValue);
+        const isAfterCurrentMonthYear = afterCurrentMonthYear(current, displayedValue);
 
-        if (selectedValue && Array.isArray(selectedValue)) {
+        if (multiple) {
+          /* eslint-disable no-loop-func */
+          if (selectedValue && selectedValue.length) {
+            selectedValue.forEach((singleValue) => {
+              if (isSameDay(current, singleValue)) {
+                cls += ` ${selectedDateClass}`;
+              }
+            });
+          } else if (isSameDay(current, displayedValue)) {
+            // keyboard change value, highlight works
+            selected = true;
+            isActiveWeek = true;
+          }
+          if (hoverValue && hoverValue.length) {
+            hoverValue.forEach((singleValue) => {
+              if (isSameDay(current, singleValue)) {
+                cls += ` ${hoveredDateClass}`;
+              }
+            });
+          }
+        } else if (selectedValue && Array.isArray(selectedValue)) {
           const rangeValue = hoverValue.length ? hoverValue : selectedValue;
           if (!isBeforeCurrentMonthYear && !isAfterCurrentMonthYear) {
             const startValue = rangeValue[0];
@@ -156,7 +180,7 @@ const DateTBody = createReactClass({
               }
             }
           }
-        } else if (isSameDay(current, value)) {
+        } else if (isSameDay(current, displayedValue)) {
           // keyboard change value, highlight works
           selected = true;
           isActiveWeek = true;

--- a/src/date/DateTHead.jsx
+++ b/src/date/DateTHead.jsx
@@ -6,11 +6,14 @@ export default
 class DateTHead extends React.Component {
   render() {
     const props = this.props;
-    const value = props.value;
-    const localeData = value.localeData();
+    const {
+      displayedValue,
+    } = props;
+    const localeData = displayedValue.localeData();
     const prefixCls = props.prefixCls;
     const veryShortWeekdays = [];
     const weekDays = [];
+    const dateObjects = [];
     const firstDayOfWeek = localeData.firstDayOfWeek();
     let showWeekNumberEl;
     const now = moment();
@@ -19,6 +22,7 @@ class DateTHead extends React.Component {
       now.day(index);
       veryShortWeekdays[dateColIndex] = localeData.weekdaysMin(now);
       weekDays[dateColIndex] = localeData.weekdaysShort(now);
+      dateObjects[dateColIndex] = now.clone();
     }
 
     if (props.showWeekNumber) {
@@ -38,9 +42,30 @@ class DateTHead extends React.Component {
           title={day}
           className={`${prefixCls}-column-header`}
         >
-          <span className={`${prefixCls}-column-header-inner`}>
-          {veryShortWeekdays[xindex]}
-          </span>
+          {props.onWeekDaysSelect ? (
+            <a
+              className={`${prefixCls}-column-header-inner`}
+              onClick={() => {
+                props.onWeekDaysSelect({
+                  month: displayedValue,
+                  weekday: (firstDayOfWeek + xindex) % DateConstants.DATE_COL_COUNT,
+                });
+              }}
+              onMouseEnter={() => {
+                props.onWeekDaysMouseEnter({
+                  month: displayedValue,
+                  weekday: (firstDayOfWeek + xindex) % DateConstants.DATE_COL_COUNT,
+                });
+              }}
+              onMouseLeave={props.onWeekDaysMouseLeave}
+            >
+              {veryShortWeekdays[xindex]}
+            </a>
+          ) : (
+            <span className={`${prefixCls}-column-header-inner`}>
+              {veryShortWeekdays[xindex]}
+            </span>
+          )}
         </th>);
     });
     return (<thead>

--- a/src/decade/DecadePanel.jsx
+++ b/src/decade/DecadePanel.jsx
@@ -5,17 +5,14 @@ const COL = 3;
 import classnames from 'classnames';
 
 function goYear(direction) {
-  const next = this.state.value.clone();
+  const next = this.props.displayedValue.clone();
   next.add(direction, 'years');
-  this.setState({
-    value: next,
-  });
+  this.props.setDisplayedValue(next);
 }
 
 function chooseDecade(year, event) {
-  const next = this.state.value.clone();
+  const next = this.props.displayedValue.clone();
   next.year(year);
-  next.month(this.state.value.month());
   this.props.onSelect(next);
   event.preventDefault();
 }
@@ -35,9 +32,10 @@ class DecadePanel extends React.Component {
   }
 
   render() {
-    const value = this.state.value;
-    const locale = this.props.locale;
-    const currentYear = value.year();
+    const props = this.props;
+    const displayedValue = props.displayedValue;
+    const locale = props.locale;
+    const currentYear = displayedValue.year();
     const startYear = parseInt(currentYear / 100, 10) * 100;
     const preYear = startYear - 10;
     const endYear = startYear + 99;

--- a/src/month/MonthPanel.jsx
+++ b/src/month/MonthPanel.jsx
@@ -4,9 +4,9 @@ import PropTypes from 'prop-types';
 import MonthTable from './MonthTable';
 
 function goYear(direction) {
-  const next = this.state.value.clone();
+  const next = this.props.displayedValue.clone();
   next.add(direction, 'year');
-  this.setAndChangeValue(next);
+  this.props.setDisplayedValue(next);
 }
 
 function noop() {
@@ -66,11 +66,11 @@ const MonthPanel = createReactClass({
 
   render() {
     const props = this.props;
-    const value = this.state.value;
+    const displayedValue = props.displayedValue;
     const cellRender = props.cellRender;
     const contentRender = props.contentRender;
     const locale = props.locale;
-    const year = value.year();
+    const year = displayedValue.year();
     const prefixCls = this.prefixCls;
     return (
       <div className={prefixCls} style={props.style}>
@@ -105,7 +105,7 @@ const MonthPanel = createReactClass({
               disabledDate={props.disabledDate}
               onSelect={this.setAndSelectValue}
               locale={locale}
-              value={value}
+              value={displayedValue}
               cellRender={cellRender}
               contentRender={contentRender}
               prefixCls={prefixCls}

--- a/src/range-calendar/CalendarPart.js
+++ b/src/range-calendar/CalendarPart.js
@@ -47,6 +47,7 @@ const CalendarPart = createReactClass({
     const newProps = {
       locale,
       value,
+      displayedValue: value,
       prefixCls,
       showTimePicker,
     };
@@ -88,7 +89,7 @@ const CalendarPart = createReactClass({
             mode={mode}
             enableNext={enableNext}
             enablePrev={enablePrev}
-            onValueChange={props.onValueChange}
+            setDisplayedValue={props.onValueChange}
             onPanelChange={props.onPanelChange}
             disabledMonth={props.disabledMonth}
           />

--- a/src/year/YearPanel.jsx
+++ b/src/year/YearPanel.jsx
@@ -5,18 +5,15 @@ const ROW = 4;
 const COL = 3;
 
 function goYear(direction) {
-  const value = this.state.value.clone();
-  value.add(direction, 'year');
-  this.setState({
-    value,
-  });
+  const next = this.props.displayedValue.clone();
+  next.add(direction, 'year');
+  this.props.setDisplayedValue(next);
 }
 
 function chooseYear(year) {
-  const value = this.state.value.clone();
-  value.year(year);
-  value.month(this.state.value.month());
-  this.props.onSelect(value);
+  const next = this.props.displayedValue.clone();
+  next.year(year);
+  this.props.onSelect(next);
 }
 
 export default
@@ -32,8 +29,8 @@ class YearPanel extends React.Component {
   }
 
   years() {
-    const value = this.state.value;
-    const currentYear = value.year();
+    const displayedValue = this.props.displayedValue;
+    const currentYear = displayedValue.year();
     const startYear = parseInt(currentYear / 10, 10) * 10;
     const previousYear = startYear - 1;
     const years = [];
@@ -55,10 +52,10 @@ class YearPanel extends React.Component {
   }
   render() {
     const props = this.props;
-    const value = this.state.value;
+    const displayedValue = props.displayedValue;
     const locale = props.locale;
     const years = this.years();
-    const currentYear = value.year();
+    const currentYear = displayedValue.year();
     const startYear = parseInt(currentYear / 10, 10) * 10;
     const endYear = startYear + 9;
     const prefixCls = this.prefixCls;
@@ -142,6 +139,7 @@ YearPanel.propTypes = {
   rootPrefixCls: PropTypes.string,
   value: PropTypes.object,
   defaultValue: PropTypes.object,
+  displayedValue: PropTypes.object,
 };
 
 YearPanel.defaultProps = {

--- a/tests/Calendar.spec.jsx
+++ b/tests/Calendar.spec.jsx
@@ -28,6 +28,34 @@ describe('Calendar', () => {
       const wrapper = mount(<Calendar showToday={false}/>);
       expect(wrapper.find('.rc-calendar-today-btn').length).toBe(0);
     });
+
+    it('render correctly with multiple selected dates for selectedValue', () => {
+      const enWrapper = render(
+        <Calendar
+          multiple
+          locale={enUS}
+          selectedValue={[
+            moment('2017-03-29').locale('en'),
+            moment('2017-03-30').locale('en'),
+          ]}
+        />
+      );
+      expect(enWrapper).toMatchSnapshot();
+    });
+
+    it('render correctly with multiple selected dates for defaultSelectedValue', () => {
+      const enWrapper = render(
+        <Calendar
+          multiple
+          locale={enUS}
+          defaultSelectedValue={[
+            moment('2017-03-29').locale('en'),
+            moment('2017-03-30').locale('en'),
+          ]}
+        />
+      );
+      expect(enWrapper).toMatchSnapshot();
+    });
   });
 
   describe('timePicker', () => {
@@ -179,7 +207,7 @@ describe('Calendar', () => {
         expected.add(-1, 'day');
 
         calendar.simulate('keyDown', { keyCode: keyCode.LEFT });
-        expect(calendar.state().value.date()).toBe(expected.date());
+        expect(calendar.state().displayedValue.date()).toBe(expected.date());
         expect(input.getDOMNode().value).toBe('');
       });
 
@@ -189,7 +217,7 @@ describe('Calendar', () => {
         const expected = original.clone();
         expected.add(1, 'day');
         calendar.simulate('keyDown', { keyCode: keyCode.RIGHT });
-        expect(calendar.state().value.date()).toBe(expected.date());
+        expect(calendar.state().displayedValue.date()).toBe(expected.date());
         expect(input.getDOMNode().value).toBe('');
       });
 
@@ -205,7 +233,7 @@ describe('Calendar', () => {
         expected.add(-1, 'day');
 
         calendar.simulate('keyDown', { keyCode: keyCode.LEFT });
-        expect(calendar.state().value.date()).toBe(expected.date());
+        expect(calendar.state().displayedValue.date()).toBe(expected.date());
         expect(input.getDOMNode().value).toBe('');
       });
 
@@ -215,7 +243,7 @@ describe('Calendar', () => {
         const expected = original.clone();
         expected.add(1, 'day');
         calendar.simulate('keyDown', { keyCode: keyCode.RIGHT });
-        expect(calendar.state().value.date()).toBe(expected.date());
+        expect(calendar.state().displayedValue.date()).toBe(expected.date());
         expect(input.getDOMNode().value).toBe('');
       });
 
@@ -224,7 +252,7 @@ describe('Calendar', () => {
         const expected = original.clone();
         expected.add(-7, 'day');
         calendar.simulate('keyDown', { keyCode: keyCode.UP });
-        expect(calendar.state().value.date()).toBe(expected.date());
+        expect(calendar.state().displayedValue.date()).toBe(expected.date());
         expect(input.getDOMNode().value).toBe('');
       });
 
@@ -233,7 +261,7 @@ describe('Calendar', () => {
         const expected = original.clone();
         expected.add(7, 'day');
         calendar.simulate('keyDown', { keyCode: keyCode.DOWN });
-        expect(calendar.state().value.date()).toBe(expected.date());
+        expect(calendar.state().displayedValue.date()).toBe(expected.date());
         expect(input.getDOMNode().value).toBe('');
       });
 
@@ -242,7 +270,7 @@ describe('Calendar', () => {
         const expected = original.clone();
         expected.add(1, 'month');
         calendar.simulate('keyDown', { keyCode: keyCode.PAGE_DOWN });
-        expect(calendar.state().value.month()).toBe(expected.month());
+        expect(calendar.state().displayedValue.month()).toBe(expected.month());
         expect(input.getDOMNode().value).toBe('');
       });
 
@@ -251,7 +279,7 @@ describe('Calendar', () => {
         const expected = original.clone();
         expected.add(-1, 'month');
         calendar.simulate('keyDown', { keyCode: keyCode.PAGE_UP });
-        expect(calendar.state().value.month()).toBe(expected.month());
+        expect(calendar.state().displayedValue.month()).toBe(expected.month());
         expect(input.getDOMNode().value).toBe('');
       });
 
@@ -263,7 +291,7 @@ describe('Calendar', () => {
           keyCode: keyCode.LEFT,
           ctrlKey: 1,
         });
-        expect(calendar.state().value.year()).toBe(expected.year());
+        expect(calendar.state().displayedValue.year()).toBe(expected.year());
         expect(input.getDOMNode().value).toBe('');
       });
 
@@ -275,7 +303,7 @@ describe('Calendar', () => {
           keyCode: keyCode.RIGHT,
           ctrlKey: 1,
         });
-        expect(calendar.state().value.year()).toBe(expected.year());
+        expect(calendar.state().displayedValue.year()).toBe(expected.year());
         expect(input.getDOMNode().value).toBe('');
       });
 
@@ -287,7 +315,7 @@ describe('Calendar', () => {
         calendar.simulate('keyDown', {
           keyCode: keyCode.HOME,
         });
-        expect(calendar.state().value.date()).toBe(expected.date());
+        expect(calendar.state().displayedValue.date()).toBe(expected.date());
       });
 
       it('END works', () => {
@@ -346,43 +374,43 @@ describe('Calendar', () => {
     });
 
     it('next month works', () => {
-      let month = calendar.state().value.month();
+      let month = calendar.state().displayedValue.month();
       if (month === 11) {
         month = -1;
       }
 
       calendar.find('.rc-calendar-next-month-btn').hostNodes().at(0).simulate('click');
 
-      expect(calendar.state().value.month()).toBe(month + 1);
+      expect(calendar.state().displayedValue.month()).toBe(month + 1);
       expect(input.getDOMNode().value).toBe('');
     });
 
     it('previous month works', () => {
-      let month = calendar.state().value.month();
+      let month = calendar.state().displayedValue.month();
       if (month === 0) {
         month = 12;
       }
 
       calendar.find('.rc-calendar-prev-month-btn').hostNodes().at(0).simulate('click');
 
-      expect(calendar.state().value.month()).toBe(month - 1);
+      expect(calendar.state().displayedValue.month()).toBe(month - 1);
       expect(input.getDOMNode().value).toBe('');
     });
 
     it('next year works', () => {
-      const year = calendar.state().value.year();
+      const year = calendar.state().displayedValue.year();
 
       calendar.find('.rc-calendar-next-year-btn').hostNodes().at(0).simulate('click');
 
-      expect(calendar.state().value.year()).toBe(year + 1);
+      expect(calendar.state().displayedValue.year()).toBe(year + 1);
     });
 
     it('previous year works', () => {
-      const year = calendar.state().value.year();
+      const year = calendar.state().displayedValue.year();
 
       calendar.find('.rc-calendar-prev-year-btn').hostNodes().at(0).simulate('click');
 
-      expect(calendar.state().value.year()).toBe(year - 1);
+      expect(calendar.state().displayedValue.year()).toBe(year - 1);
     });
 
     it('onSelect works', () => {
@@ -414,7 +442,7 @@ describe('Calendar', () => {
       expect(calendar.find('.rc-calendar-month-panel').hostNodes().length).toBe(1);
       expect(calendar.find('.rc-calendar-month-panel-month').hostNodes().length).toBe(12);
       calendar.find('.rc-calendar-month-panel-month').hostNodes().at(9).simulate('click');
-      expect(calendar.state().value.month()).toBe(9);
+      expect(calendar.state().displayedValue.month()).toBe(9);
     });
 
     it('top year panel shows', () => {
@@ -426,7 +454,7 @@ describe('Calendar', () => {
       const year = calendar.find('.rc-calendar-year-panel-year').hostNodes().at(9);
       year.simulate('click');
       text = year.text();
-      expect(String(calendar.state().value.year())).toBe(text);
+      expect(String(calendar.state().displayedValue.year())).toBe(text);
     });
 
     it('year panel works', () => {
@@ -439,7 +467,7 @@ describe('Calendar', () => {
       year.simulate('click');
       text = year.text();
       calendar.find('.rc-calendar-month-panel-month').hostNodes().at(9).simulate('click');
-      expect(String(calendar.state().value.year())).toBe(text);
+      expect(String(calendar.state().displayedValue.year())).toBe(text);
       expect(input.getDOMNode().value).toBe('');
     });
 
@@ -453,6 +481,57 @@ describe('Calendar', () => {
     });
   });
 
+  describe('date ranges', () => {
+    it('selecting all sundays works', () => {
+      const onSelect = jest.fn();
+
+      const calendar = mount(
+        <Calendar
+          format={format}
+          onSelect={onSelect}
+          disabledDate={() => false}
+          multiple
+          selectWeekDays
+        />
+      );
+
+      calendar.find('.rc-calendar-column-header-inner').first().hostNodes().simulate('click');
+
+      expect(calendar).toMatchSnapshot();
+
+      expect(onSelect.mock.calls[0][0].map((date) => date.format(format))).toEqual([
+        '2017-03-05',
+        '2017-03-12',
+        '2017-03-19',
+        '2017-03-26',
+      ]);
+    });
+
+    it('selecting the entire month works', () => {
+      const onSelect = jest.fn();
+
+      const calendar = mount(
+        <Calendar
+          format={format}
+          onSelect={onSelect}
+          disabledDate={() => false}
+          multiple
+          selectMonths
+        />
+      );
+
+      calendar.find('.rc-calendar-month-select').first().hostNodes().simulate('click');
+
+      expect(calendar).toMatchSnapshot();
+
+      const expected = [];
+      for (let i = 1; i <= 31; i++) {
+        expected.push(`2017-03-${i < 10 ? '0' : ''}${i}`);
+      }
+
+      expect(onSelect.mock.calls[0][0].map((date) => date.format(format))).toEqual(expected);
+    });
+  });
 
   describe('input', () => {
     it('change will fire onSelect/onChange', () => {

--- a/tests/MonthCalendar.spec.js
+++ b/tests/MonthCalendar.spec.js
@@ -56,28 +56,28 @@ describe('MonthCalendar', () => {
       wrapper.simulate('keydown', {
         keyCode: keyCode.DOWN,
       });
-      expect(wrapper.state().value.month()).toBe(7);
+      expect(wrapper.state().displayedValue.month()).toBe(7);
     });
 
     it('UP', () => {
       wrapper.simulate('keydown', {
         keyCode: keyCode.UP,
       });
-      expect(wrapper.state().value.month()).toBe(1);
+      expect(wrapper.state().displayedValue.month()).toBe(1);
     });
 
     it('LEFT', () => {
       wrapper.simulate('keydown', {
         keyCode: keyCode.LEFT,
       });
-      expect(wrapper.state().value.month()).toBe(3);
+      expect(wrapper.state().displayedValue.month()).toBe(3);
     });
 
     it('RIGHT', () => {
       wrapper.simulate('keydown', {
         keyCode: keyCode.RIGHT,
       });
-      expect(wrapper.state().value.month()).toBe(5);
+      expect(wrapper.state().displayedValue.month()).toBe(5);
     });
 
     it('CTRL + LEFT', () => {
@@ -85,8 +85,8 @@ describe('MonthCalendar', () => {
         keyCode: keyCode.LEFT,
         ctrlKey: 1,
       });
-      expect(wrapper.state().value.month()).toBe(4);
-      expect(wrapper.state().value.year()).toBe(2016);
+      expect(wrapper.state().displayedValue.month()).toBe(4);
+      expect(wrapper.state().displayedValue.year()).toBe(2016);
     });
 
     it('CTRL + RIGHT', () => {
@@ -94,16 +94,16 @@ describe('MonthCalendar', () => {
         keyCode: keyCode.RIGHT,
         ctrlKey: 1,
       });
-      expect(wrapper.state().value.month()).toBe(4);
-      expect(wrapper.state().value.year()).toBe(2018);
+      expect(wrapper.state().displayedValue.month()).toBe(4);
+      expect(wrapper.state().displayedValue.year()).toBe(2018);
     });
 
     it('ignore other keys', () => {
       wrapper.simulate('keydown', {
         keyCode: keyCode.A,
       });
-      expect(wrapper.state().value.month()).toBe(4);
-      expect(wrapper.state().value.year()).toBe(2017);
+      expect(wrapper.state().displayedValue.month()).toBe(4);
+      expect(wrapper.state().displayedValue.year()).toBe(2017);
     });
   });
 });

--- a/tests/__snapshots__/Calendar.spec.jsx.snap
+++ b/tests/__snapshots__/Calendar.spec.jsx.snap
@@ -1926,6 +1926,2934 @@ exports[`Calendar controlled panels render controlled panels correctly 2`] = `
 </div>
 `;
 
+exports[`Calendar date ranges selecting all sundays works 1`] = `
+<Calendar
+  className=""
+  disabledDate={[Function]}
+  format="YYYY-MM-DD"
+  locale={
+    Object {
+      "backToToday": "Back to today",
+      "clear": "Clear",
+      "dateFormat": "M/D/YYYY",
+      "dateSelect": "Select date",
+      "dateTimeFormat": "M/D/YYYY HH:mm:ss",
+      "dayFormat": "D",
+      "decadeSelect": "Choose a decade",
+      "month": "Month",
+      "monthBeforeYear": true,
+      "monthSelect": "Choose a month",
+      "nextCentury": "Next century",
+      "nextDecade": "Next decade",
+      "nextMonth": "Next month (PageDown)",
+      "nextYear": "Next year (Control + right)",
+      "now": "Now",
+      "ok": "Ok",
+      "previousCentury": "Last century",
+      "previousDecade": "Last decade",
+      "previousMonth": "Previous month (PageUp)",
+      "previousYear": "Last year (Control + left)",
+      "timeSelect": "Select time",
+      "today": "Today",
+      "year": "Year",
+      "yearFormat": "YYYY",
+      "yearSelect": "Choose a year",
+    }
+  }
+  multiple={true}
+  onChange={[Function]}
+  onClear={[Function]}
+  onKeyDown={[Function]}
+  onOk={[Function]}
+  onPanelChange={[Function]}
+  onSelect={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          Array [
+            "2017-03-04T23:00:00.000Z",
+            "2017-03-11T23:00:00.000Z",
+            "2017-03-18T23:00:00.000Z",
+            "2017-03-25T23:00:00.000Z",
+          ],
+          undefined,
+        ],
+      ],
+    }
+  }
+  prefixCls="rc-calendar"
+  renderFooter={[Function]}
+  renderSidebar={[Function]}
+  selectWeekDays={true}
+  showDateInput={true}
+  showToday={true}
+  style={Object {}}
+  timePicker={null}
+  visible={true}
+>
+  <div
+    className="rc-calendar"
+    onKeyDown={[Function]}
+    style={Object {}}
+    tabIndex="0"
+  >
+    <div
+      className="rc-calendar-panel"
+      key="panel"
+    >
+      <DateInput
+        disabledDate={[Function]}
+        format="YYYY-MM-DD"
+        key="date-input"
+        locale={
+          Object {
+            "backToToday": "Back to today",
+            "clear": "Clear",
+            "dateFormat": "M/D/YYYY",
+            "dateSelect": "Select date",
+            "dateTimeFormat": "M/D/YYYY HH:mm:ss",
+            "dayFormat": "D",
+            "decadeSelect": "Choose a decade",
+            "month": "Month",
+            "monthBeforeYear": true,
+            "monthSelect": "Choose a month",
+            "nextCentury": "Next century",
+            "nextDecade": "Next decade",
+            "nextMonth": "Next month (PageDown)",
+            "nextYear": "Next year (Control + right)",
+            "now": "Now",
+            "ok": "Ok",
+            "previousCentury": "Last century",
+            "previousDecade": "Last decade",
+            "previousMonth": "Previous month (PageUp)",
+            "previousYear": "Last year (Control + left)",
+            "timeSelect": "Select time",
+            "today": "Today",
+            "year": "Year",
+            "yearFormat": "YYYY",
+            "yearSelect": "Choose a year",
+          }
+        }
+        multiple={true}
+        onChange={[Function]}
+        onClear={[Function]}
+        prefixCls="rc-calendar"
+        selectedValue={
+          Array [
+            "2017-03-04T23:00:00.000Z",
+            "2017-03-11T23:00:00.000Z",
+            "2017-03-18T23:00:00.000Z",
+            "2017-03-25T23:00:00.000Z",
+          ]
+        }
+        showClear={true}
+        value={
+          Array [
+            "2017-03-28T22:00:00.000Z",
+          ]
+        }
+      >
+        <div
+          className="rc-calendar-input-wrap"
+        >
+          <div
+            className="rc-calendar-date-input-wrap"
+          >
+            <input
+              className="rc-calendar-input "
+              onChange={[Function]}
+              value="2017-03-05, 2017-03-12, 2017-03-19, 2017-03-26"
+            />
+          </div>
+          <a
+            className="rc-calendar-clear-btn"
+            onClick={[Function]}
+            role="button"
+            title="Clear"
+          />
+        </div>
+      </DateInput>
+      <div
+        className="rc-calendar-date-panel"
+      >
+        <CalendarHeader
+          displayedValue={"2017-03-28T22:00:00.000Z"}
+          enableNext={1}
+          enablePrev={1}
+          locale={
+            Object {
+              "backToToday": "Back to today",
+              "clear": "Clear",
+              "dateFormat": "M/D/YYYY",
+              "dateSelect": "Select date",
+              "dateTimeFormat": "M/D/YYYY HH:mm:ss",
+              "dayFormat": "D",
+              "decadeSelect": "Choose a decade",
+              "month": "Month",
+              "monthBeforeYear": true,
+              "monthSelect": "Choose a month",
+              "nextCentury": "Next century",
+              "nextDecade": "Next decade",
+              "nextMonth": "Next month (PageDown)",
+              "nextYear": "Next year (Control + right)",
+              "now": "Now",
+              "ok": "Ok",
+              "previousCentury": "Last century",
+              "previousDecade": "Last decade",
+              "previousMonth": "Previous month (PageUp)",
+              "previousYear": "Last year (Control + left)",
+              "timeSelect": "Select time",
+              "today": "Today",
+              "year": "Year",
+              "yearFormat": "YYYY",
+              "yearSelect": "Choose a year",
+            }
+          }
+          mode="date"
+          multiple={true}
+          onPanelChange={[Function]}
+          onValueChange={[Function]}
+          prefixCls="rc-calendar"
+          setDisplayedValue={[Function]}
+          showTimePicker={false}
+          value={
+            Array [
+              "2017-03-28T22:00:00.000Z",
+            ]
+          }
+        >
+          <div
+            className="rc-calendar-header"
+          >
+            <div
+              style={
+                Object {
+                  "position": "relative",
+                }
+              }
+            >
+              <a
+                className="rc-calendar-prev-year-btn"
+                onClick={[Function]}
+                role="button"
+                title="Last year (Control + left)"
+              />
+              <a
+                className="rc-calendar-prev-month-btn"
+                onClick={[Function]}
+                role="button"
+                title="Previous month (PageUp)"
+              />
+              <span
+                className="rc-calendar-my-select"
+              >
+                <a
+                  className="rc-calendar-month-select"
+                  key=".0"
+                  onClick={[Function]}
+                  role="button"
+                  title="Choose a month"
+                >
+                  Mar
+                </a>
+                <a
+                  className="rc-calendar-year-select"
+                  key=".2"
+                  onClick={[Function]}
+                  role="button"
+                  title="Choose a year"
+                >
+                  2017
+                </a>
+              </span>
+              <a
+                className="rc-calendar-next-month-btn"
+                onClick={[Function]}
+                title="Next month (PageDown)"
+              />
+              <a
+                className="rc-calendar-next-year-btn"
+                onClick={[Function]}
+                title="Next year (Control + right)"
+              />
+            </div>
+          </div>
+        </CalendarHeader>
+        <div
+          className="rc-calendar-body"
+        >
+          <DateTable
+            disabledDate={[Function]}
+            displayedValue={"2017-03-28T22:00:00.000Z"}
+            locale={
+              Object {
+                "backToToday": "Back to today",
+                "clear": "Clear",
+                "dateFormat": "M/D/YYYY",
+                "dateSelect": "Select date",
+                "dateTimeFormat": "M/D/YYYY HH:mm:ss",
+                "dayFormat": "D",
+                "decadeSelect": "Choose a decade",
+                "month": "Month",
+                "monthBeforeYear": true,
+                "monthSelect": "Choose a month",
+                "nextCentury": "Next century",
+                "nextDecade": "Next decade",
+                "nextMonth": "Next month (PageDown)",
+                "nextYear": "Next year (Control + right)",
+                "now": "Now",
+                "ok": "Ok",
+                "previousCentury": "Last century",
+                "previousDecade": "Last decade",
+                "previousMonth": "Previous month (PageUp)",
+                "previousYear": "Last year (Control + left)",
+                "timeSelect": "Select time",
+                "today": "Today",
+                "year": "Year",
+                "yearFormat": "YYYY",
+                "yearSelect": "Choose a year",
+              }
+            }
+            multiple={true}
+            onSelect={[Function]}
+            onWeekDaysMouseEnter={[Function]}
+            onWeekDaysMouseLeave={[Function]}
+            onWeekDaysSelect={[Function]}
+            prefixCls="rc-calendar"
+            selectedValue={
+              Array [
+                "2017-03-04T23:00:00.000Z",
+                "2017-03-11T23:00:00.000Z",
+                "2017-03-18T23:00:00.000Z",
+                "2017-03-25T23:00:00.000Z",
+              ]
+            }
+            value={
+              Array [
+                "2017-03-28T22:00:00.000Z",
+              ]
+            }
+          >
+            <table
+              cellSpacing="0"
+              className="rc-calendar-table"
+              role="grid"
+            >
+              <DateTHead
+                disabledDate={[Function]}
+                displayedValue={"2017-03-28T22:00:00.000Z"}
+                locale={
+                  Object {
+                    "backToToday": "Back to today",
+                    "clear": "Clear",
+                    "dateFormat": "M/D/YYYY",
+                    "dateSelect": "Select date",
+                    "dateTimeFormat": "M/D/YYYY HH:mm:ss",
+                    "dayFormat": "D",
+                    "decadeSelect": "Choose a decade",
+                    "month": "Month",
+                    "monthBeforeYear": true,
+                    "monthSelect": "Choose a month",
+                    "nextCentury": "Next century",
+                    "nextDecade": "Next decade",
+                    "nextMonth": "Next month (PageDown)",
+                    "nextYear": "Next year (Control + right)",
+                    "now": "Now",
+                    "ok": "Ok",
+                    "previousCentury": "Last century",
+                    "previousDecade": "Last decade",
+                    "previousMonth": "Previous month (PageUp)",
+                    "previousYear": "Last year (Control + left)",
+                    "timeSelect": "Select time",
+                    "today": "Today",
+                    "year": "Year",
+                    "yearFormat": "YYYY",
+                    "yearSelect": "Choose a year",
+                  }
+                }
+                multiple={true}
+                onSelect={[Function]}
+                onWeekDaysMouseEnter={[Function]}
+                onWeekDaysMouseLeave={[Function]}
+                onWeekDaysSelect={[Function]}
+                prefixCls="rc-calendar"
+                selectedValue={
+                  Array [
+                    "2017-03-04T23:00:00.000Z",
+                    "2017-03-11T23:00:00.000Z",
+                    "2017-03-18T23:00:00.000Z",
+                    "2017-03-25T23:00:00.000Z",
+                  ]
+                }
+                value={
+                  Array [
+                    "2017-03-28T22:00:00.000Z",
+                  ]
+                }
+              >
+                <thead>
+                  <tr
+                    role="row"
+                  >
+                    <th
+                      className="rc-calendar-column-header"
+                      key="0"
+                      role="columnheader"
+                      title="Sun"
+                    >
+                      <a
+                        className="rc-calendar-column-header-inner"
+                        onClick={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                      >
+                        Su
+                      </a>
+                    </th>
+                    <th
+                      className="rc-calendar-column-header"
+                      key="1"
+                      role="columnheader"
+                      title="Mon"
+                    >
+                      <a
+                        className="rc-calendar-column-header-inner"
+                        onClick={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                      >
+                        Mo
+                      </a>
+                    </th>
+                    <th
+                      className="rc-calendar-column-header"
+                      key="2"
+                      role="columnheader"
+                      title="Tue"
+                    >
+                      <a
+                        className="rc-calendar-column-header-inner"
+                        onClick={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                      >
+                        Tu
+                      </a>
+                    </th>
+                    <th
+                      className="rc-calendar-column-header"
+                      key="3"
+                      role="columnheader"
+                      title="Wed"
+                    >
+                      <a
+                        className="rc-calendar-column-header-inner"
+                        onClick={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                      >
+                        We
+                      </a>
+                    </th>
+                    <th
+                      className="rc-calendar-column-header"
+                      key="4"
+                      role="columnheader"
+                      title="Thu"
+                    >
+                      <a
+                        className="rc-calendar-column-header-inner"
+                        onClick={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                      >
+                        Th
+                      </a>
+                    </th>
+                    <th
+                      className="rc-calendar-column-header"
+                      key="5"
+                      role="columnheader"
+                      title="Fri"
+                    >
+                      <a
+                        className="rc-calendar-column-header-inner"
+                        onClick={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                      >
+                        Fr
+                      </a>
+                    </th>
+                    <th
+                      className="rc-calendar-column-header"
+                      key="6"
+                      role="columnheader"
+                      title="Sat"
+                    >
+                      <a
+                        className="rc-calendar-column-header-inner"
+                        onClick={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                      >
+                        Sa
+                      </a>
+                    </th>
+                  </tr>
+                </thead>
+              </DateTHead>
+              <DateTBody
+                disabledDate={[Function]}
+                displayedValue={"2017-03-28T22:00:00.000Z"}
+                hoverValue={Array []}
+                locale={
+                  Object {
+                    "backToToday": "Back to today",
+                    "clear": "Clear",
+                    "dateFormat": "M/D/YYYY",
+                    "dateSelect": "Select date",
+                    "dateTimeFormat": "M/D/YYYY HH:mm:ss",
+                    "dayFormat": "D",
+                    "decadeSelect": "Choose a decade",
+                    "month": "Month",
+                    "monthBeforeYear": true,
+                    "monthSelect": "Choose a month",
+                    "nextCentury": "Next century",
+                    "nextDecade": "Next decade",
+                    "nextMonth": "Next month (PageDown)",
+                    "nextYear": "Next year (Control + right)",
+                    "now": "Now",
+                    "ok": "Ok",
+                    "previousCentury": "Last century",
+                    "previousDecade": "Last decade",
+                    "previousMonth": "Previous month (PageUp)",
+                    "previousYear": "Last year (Control + left)",
+                    "timeSelect": "Select time",
+                    "today": "Today",
+                    "year": "Year",
+                    "yearFormat": "YYYY",
+                    "yearSelect": "Choose a year",
+                  }
+                }
+                multiple={true}
+                onSelect={[Function]}
+                onWeekDaysMouseEnter={[Function]}
+                onWeekDaysMouseLeave={[Function]}
+                onWeekDaysSelect={[Function]}
+                prefixCls="rc-calendar"
+                selectedValue={
+                  Array [
+                    "2017-03-04T23:00:00.000Z",
+                    "2017-03-11T23:00:00.000Z",
+                    "2017-03-18T23:00:00.000Z",
+                    "2017-03-25T23:00:00.000Z",
+                  ]
+                }
+                value={
+                  Array [
+                    "2017-03-28T22:00:00.000Z",
+                  ]
+                }
+              >
+                <tbody
+                  className="rc-calendar-tbody"
+                >
+                  <tr
+                    className=""
+                    key="0"
+                    role="row"
+                  >
+                    <td
+                      className="rc-calendar-cell rc-calendar-last-month-cell"
+                      key="0"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="February 26, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-1-26"
+                      >
+                        26
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-last-month-cell"
+                      key="1"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="February 27, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-1-27"
+                      >
+                        27
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-last-month-cell"
+                      key="2"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="February 28, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-1-28"
+                      >
+                        28
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell"
+                      key="3"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 1, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-1"
+                      >
+                        1
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell"
+                      key="4"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 2, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-2"
+                      >
+                        2
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell"
+                      key="5"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 3, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-3"
+                      >
+                        3
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell"
+                      key="6"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 4, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-4"
+                      >
+                        4
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    className=""
+                    key="1"
+                    role="row"
+                  >
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="7"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 5, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-5"
+                      >
+                        5
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell"
+                      key="8"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 6, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-6"
+                      >
+                        6
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell"
+                      key="9"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 7, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-7"
+                      >
+                        7
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell"
+                      key="10"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 8, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-8"
+                      >
+                        8
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell"
+                      key="11"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 9, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-9"
+                      >
+                        9
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell"
+                      key="12"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 10, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-10"
+                      >
+                        10
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell"
+                      key="13"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 11, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-11"
+                      >
+                        11
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    className=""
+                    key="2"
+                    role="row"
+                  >
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="14"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 12, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-12"
+                      >
+                        12
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell"
+                      key="15"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 13, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-13"
+                      >
+                        13
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell"
+                      key="16"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 14, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-14"
+                      >
+                        14
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell"
+                      key="17"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 15, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-15"
+                      >
+                        15
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell"
+                      key="18"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 16, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-16"
+                      >
+                        16
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell"
+                      key="19"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 17, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-17"
+                      >
+                        17
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell"
+                      key="20"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 18, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-18"
+                      >
+                        18
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    className=""
+                    key="3"
+                    role="row"
+                  >
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="21"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 19, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-19"
+                      >
+                        19
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell"
+                      key="22"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 20, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-20"
+                      >
+                        20
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell"
+                      key="23"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 21, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-21"
+                      >
+                        21
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell"
+                      key="24"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 22, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-22"
+                      >
+                        22
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell"
+                      key="25"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 23, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-23"
+                      >
+                        23
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell"
+                      key="26"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 24, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-24"
+                      >
+                        24
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell"
+                      key="27"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 25, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-25"
+                      >
+                        25
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    className="rc-calendar-current-week"
+                    key="4"
+                    role="row"
+                  >
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="28"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 26, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-26"
+                      >
+                        26
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell"
+                      key="29"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 27, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-27"
+                      >
+                        27
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell"
+                      key="30"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 28, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-28"
+                      >
+                        28
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-today"
+                      key="31"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 29, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-29"
+                      >
+                        29
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell"
+                      key="32"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 30, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-30"
+                      >
+                        30
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell"
+                      key="33"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 31, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-31"
+                      >
+                        31
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-next-month-btn-day"
+                      key="34"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="April 1, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-3-1"
+                      >
+                        1
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    className=""
+                    key="5"
+                    role="row"
+                  >
+                    <td
+                      className="rc-calendar-cell rc-calendar-next-month-btn-day"
+                      key="35"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="April 2, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-3-2"
+                      >
+                        2
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-next-month-btn-day"
+                      key="36"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="April 3, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-3-3"
+                      >
+                        3
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-next-month-btn-day"
+                      key="37"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="April 4, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-3-4"
+                      >
+                        4
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-next-month-btn-day"
+                      key="38"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="April 5, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-3-5"
+                      >
+                        5
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-next-month-btn-day"
+                      key="39"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="April 6, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-3-6"
+                      >
+                        6
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-next-month-btn-day"
+                      key="40"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="April 7, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-3-7"
+                      >
+                        7
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-next-month-btn-day"
+                      key="41"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="April 8, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-3-8"
+                      >
+                        8
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </DateTBody>
+            </table>
+          </DateTable>
+        </div>
+        <CalendarFooter
+          disabledDate={[Function]}
+          displayedValue={"2017-03-28T22:00:00.000Z"}
+          locale={
+            Object {
+              "backToToday": "Back to today",
+              "clear": "Clear",
+              "dateFormat": "M/D/YYYY",
+              "dateSelect": "Select date",
+              "dateTimeFormat": "M/D/YYYY HH:mm:ss",
+              "dayFormat": "D",
+              "decadeSelect": "Choose a decade",
+              "month": "Month",
+              "monthBeforeYear": true,
+              "monthSelect": "Choose a month",
+              "nextCentury": "Next century",
+              "nextDecade": "Next decade",
+              "nextMonth": "Next month (PageDown)",
+              "nextYear": "Next year (Control + right)",
+              "now": "Now",
+              "ok": "Ok",
+              "previousCentury": "Last century",
+              "previousDecade": "Last decade",
+              "previousMonth": "Previous month (PageUp)",
+              "previousYear": "Last year (Control + left)",
+              "timeSelect": "Select time",
+              "today": "Today",
+              "year": "Year",
+              "yearFormat": "YYYY",
+              "yearSelect": "Choose a year",
+            }
+          }
+          multiple={true}
+          okDisabled={false}
+          onCloseTimePicker={[Function]}
+          onOk={[Function]}
+          onOpenTimePicker={[Function]}
+          onSelect={[Function]}
+          onToday={[Function]}
+          prefixCls="rc-calendar"
+          renderFooter={[Function]}
+          selectedValue={
+            Array [
+              "2017-03-04T23:00:00.000Z",
+              "2017-03-11T23:00:00.000Z",
+              "2017-03-18T23:00:00.000Z",
+              "2017-03-25T23:00:00.000Z",
+            ]
+          }
+          showDateInput={true}
+          showTimePicker={false}
+          showToday={true}
+          timePicker={null}
+          value={
+            Array [
+              "2017-03-28T22:00:00.000Z",
+            ]
+          }
+        >
+          <div
+            className="rc-calendar-footer"
+          >
+            <span
+              className="rc-calendar-footer-btn"
+            >
+              <TodayButton
+                disabledDate={[Function]}
+                displayedValue={"2017-03-28T22:00:00.000Z"}
+                key=".0"
+                locale={
+                  Object {
+                    "backToToday": "Back to today",
+                    "clear": "Clear",
+                    "dateFormat": "M/D/YYYY",
+                    "dateSelect": "Select date",
+                    "dateTimeFormat": "M/D/YYYY HH:mm:ss",
+                    "dayFormat": "D",
+                    "decadeSelect": "Choose a decade",
+                    "month": "Month",
+                    "monthBeforeYear": true,
+                    "monthSelect": "Choose a month",
+                    "nextCentury": "Next century",
+                    "nextDecade": "Next decade",
+                    "nextMonth": "Next month (PageDown)",
+                    "nextYear": "Next year (Control + right)",
+                    "now": "Now",
+                    "ok": "Ok",
+                    "previousCentury": "Last century",
+                    "previousDecade": "Last decade",
+                    "previousMonth": "Previous month (PageUp)",
+                    "previousYear": "Last year (Control + left)",
+                    "timeSelect": "Select time",
+                    "today": "Today",
+                    "year": "Year",
+                    "yearFormat": "YYYY",
+                    "yearSelect": "Choose a year",
+                  }
+                }
+                multiple={true}
+                okDisabled={false}
+                onCloseTimePicker={[Function]}
+                onOk={[Function]}
+                onOpenTimePicker={[Function]}
+                onSelect={[Function]}
+                onToday={[Function]}
+                prefixCls="rc-calendar"
+                renderFooter={[Function]}
+                selectedValue={
+                  Array [
+                    "2017-03-04T23:00:00.000Z",
+                    "2017-03-11T23:00:00.000Z",
+                    "2017-03-18T23:00:00.000Z",
+                    "2017-03-25T23:00:00.000Z",
+                  ]
+                }
+                showDateInput={true}
+                showTimePicker={false}
+                showToday={true}
+                timePicker={null}
+                value={
+                  Array [
+                    "2017-03-28T22:00:00.000Z",
+                  ]
+                }
+              >
+                <a
+                  className="rc-calendar-today-btn "
+                  onClick={[Function]}
+                  role="button"
+                  title="March 29, 2017"
+                >
+                  Today
+                </a>
+              </TodayButton>
+            </span>
+          </div>
+        </CalendarFooter>
+      </div>
+    </div>
+  </div>
+</Calendar>
+`;
+
+exports[`Calendar date ranges selecting the entire month works 1`] = `
+<Calendar
+  className=""
+  disabledDate={[Function]}
+  format="YYYY-MM-DD"
+  locale={
+    Object {
+      "backToToday": "Back to today",
+      "clear": "Clear",
+      "dateFormat": "M/D/YYYY",
+      "dateSelect": "Select date",
+      "dateTimeFormat": "M/D/YYYY HH:mm:ss",
+      "dayFormat": "D",
+      "decadeSelect": "Choose a decade",
+      "month": "Month",
+      "monthBeforeYear": true,
+      "monthSelect": "Choose a month",
+      "nextCentury": "Next century",
+      "nextDecade": "Next decade",
+      "nextMonth": "Next month (PageDown)",
+      "nextYear": "Next year (Control + right)",
+      "now": "Now",
+      "ok": "Ok",
+      "previousCentury": "Last century",
+      "previousDecade": "Last decade",
+      "previousMonth": "Previous month (PageUp)",
+      "previousYear": "Last year (Control + left)",
+      "timeSelect": "Select time",
+      "today": "Today",
+      "year": "Year",
+      "yearFormat": "YYYY",
+      "yearSelect": "Choose a year",
+    }
+  }
+  multiple={true}
+  onChange={[Function]}
+  onClear={[Function]}
+  onKeyDown={[Function]}
+  onOk={[Function]}
+  onPanelChange={[Function]}
+  onSelect={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          Array [
+            "2017-02-28T23:00:00.000Z",
+            "2017-03-01T23:00:00.000Z",
+            "2017-03-02T23:00:00.000Z",
+            "2017-03-03T23:00:00.000Z",
+            "2017-03-04T23:00:00.000Z",
+            "2017-03-05T23:00:00.000Z",
+            "2017-03-06T23:00:00.000Z",
+            "2017-03-07T23:00:00.000Z",
+            "2017-03-08T23:00:00.000Z",
+            "2017-03-09T23:00:00.000Z",
+            "2017-03-10T23:00:00.000Z",
+            "2017-03-11T23:00:00.000Z",
+            "2017-03-12T23:00:00.000Z",
+            "2017-03-13T23:00:00.000Z",
+            "2017-03-14T23:00:00.000Z",
+            "2017-03-15T23:00:00.000Z",
+            "2017-03-16T23:00:00.000Z",
+            "2017-03-17T23:00:00.000Z",
+            "2017-03-18T23:00:00.000Z",
+            "2017-03-19T23:00:00.000Z",
+            "2017-03-20T23:00:00.000Z",
+            "2017-03-21T23:00:00.000Z",
+            "2017-03-22T23:00:00.000Z",
+            "2017-03-23T23:00:00.000Z",
+            "2017-03-24T23:00:00.000Z",
+            "2017-03-25T23:00:00.000Z",
+            "2017-03-26T22:00:00.000Z",
+            "2017-03-27T22:00:00.000Z",
+            "2017-03-28T22:00:00.000Z",
+            "2017-03-29T22:00:00.000Z",
+            "2017-03-30T22:00:00.000Z",
+          ],
+          undefined,
+        ],
+      ],
+    }
+  }
+  prefixCls="rc-calendar"
+  renderFooter={[Function]}
+  renderSidebar={[Function]}
+  selectMonths={true}
+  showDateInput={true}
+  showToday={true}
+  style={Object {}}
+  timePicker={null}
+  visible={true}
+>
+  <div
+    className="rc-calendar"
+    onKeyDown={[Function]}
+    style={Object {}}
+    tabIndex="0"
+  >
+    <div
+      className="rc-calendar-panel"
+      key="panel"
+    >
+      <DateInput
+        disabledDate={[Function]}
+        format="YYYY-MM-DD"
+        key="date-input"
+        locale={
+          Object {
+            "backToToday": "Back to today",
+            "clear": "Clear",
+            "dateFormat": "M/D/YYYY",
+            "dateSelect": "Select date",
+            "dateTimeFormat": "M/D/YYYY HH:mm:ss",
+            "dayFormat": "D",
+            "decadeSelect": "Choose a decade",
+            "month": "Month",
+            "monthBeforeYear": true,
+            "monthSelect": "Choose a month",
+            "nextCentury": "Next century",
+            "nextDecade": "Next decade",
+            "nextMonth": "Next month (PageDown)",
+            "nextYear": "Next year (Control + right)",
+            "now": "Now",
+            "ok": "Ok",
+            "previousCentury": "Last century",
+            "previousDecade": "Last decade",
+            "previousMonth": "Previous month (PageUp)",
+            "previousYear": "Last year (Control + left)",
+            "timeSelect": "Select time",
+            "today": "Today",
+            "year": "Year",
+            "yearFormat": "YYYY",
+            "yearSelect": "Choose a year",
+          }
+        }
+        multiple={true}
+        onChange={[Function]}
+        onClear={[Function]}
+        prefixCls="rc-calendar"
+        selectedValue={
+          Array [
+            "2017-02-28T23:00:00.000Z",
+            "2017-03-01T23:00:00.000Z",
+            "2017-03-02T23:00:00.000Z",
+            "2017-03-03T23:00:00.000Z",
+            "2017-03-04T23:00:00.000Z",
+            "2017-03-05T23:00:00.000Z",
+            "2017-03-06T23:00:00.000Z",
+            "2017-03-07T23:00:00.000Z",
+            "2017-03-08T23:00:00.000Z",
+            "2017-03-09T23:00:00.000Z",
+            "2017-03-10T23:00:00.000Z",
+            "2017-03-11T23:00:00.000Z",
+            "2017-03-12T23:00:00.000Z",
+            "2017-03-13T23:00:00.000Z",
+            "2017-03-14T23:00:00.000Z",
+            "2017-03-15T23:00:00.000Z",
+            "2017-03-16T23:00:00.000Z",
+            "2017-03-17T23:00:00.000Z",
+            "2017-03-18T23:00:00.000Z",
+            "2017-03-19T23:00:00.000Z",
+            "2017-03-20T23:00:00.000Z",
+            "2017-03-21T23:00:00.000Z",
+            "2017-03-22T23:00:00.000Z",
+            "2017-03-23T23:00:00.000Z",
+            "2017-03-24T23:00:00.000Z",
+            "2017-03-25T23:00:00.000Z",
+            "2017-03-26T22:00:00.000Z",
+            "2017-03-27T22:00:00.000Z",
+            "2017-03-28T22:00:00.000Z",
+            "2017-03-29T22:00:00.000Z",
+            "2017-03-30T22:00:00.000Z",
+          ]
+        }
+        showClear={true}
+        value={
+          Array [
+            "2017-03-28T22:00:00.000Z",
+          ]
+        }
+      >
+        <div
+          className="rc-calendar-input-wrap"
+        >
+          <div
+            className="rc-calendar-date-input-wrap"
+          >
+            <input
+              className="rc-calendar-input "
+              onChange={[Function]}
+              value="2017-03-01, 2017-03-02, 2017-03-03, 2017-03-04, 2017-03-05, 2017-03-06, 2017-03-07, 2017-03-08, 2017-03-09, 2017-03-10, 2017-03-11, 2017-03-12, 2017-03-13, 2017-03-14, 2017-03-15, 2017-03-16, 2017-03-17, 2017-03-18, 2017-03-19, 2017-03-20, 2017-03-21, 2017-03-22, 2017-03-23, 2017-03-24, 2017-03-25, 2017-03-26, 2017-03-27, 2017-03-28, 2017-03-29, 2017-03-30, 2017-03-31"
+            />
+          </div>
+          <a
+            className="rc-calendar-clear-btn"
+            onClick={[Function]}
+            role="button"
+            title="Clear"
+          />
+        </div>
+      </DateInput>
+      <div
+        className="rc-calendar-date-panel"
+      >
+        <CalendarHeader
+          displayedValue={"2017-03-28T22:00:00.000Z"}
+          enableNext={1}
+          enablePrev={1}
+          locale={
+            Object {
+              "backToToday": "Back to today",
+              "clear": "Clear",
+              "dateFormat": "M/D/YYYY",
+              "dateSelect": "Select date",
+              "dateTimeFormat": "M/D/YYYY HH:mm:ss",
+              "dayFormat": "D",
+              "decadeSelect": "Choose a decade",
+              "month": "Month",
+              "monthBeforeYear": true,
+              "monthSelect": "Choose a month",
+              "nextCentury": "Next century",
+              "nextDecade": "Next decade",
+              "nextMonth": "Next month (PageDown)",
+              "nextYear": "Next year (Control + right)",
+              "now": "Now",
+              "ok": "Ok",
+              "previousCentury": "Last century",
+              "previousDecade": "Last decade",
+              "previousMonth": "Previous month (PageUp)",
+              "previousYear": "Last year (Control + left)",
+              "timeSelect": "Select time",
+              "today": "Today",
+              "year": "Year",
+              "yearFormat": "YYYY",
+              "yearSelect": "Choose a year",
+            }
+          }
+          mode="date"
+          multiple={true}
+          onMonthMouseEnter={[Function]}
+          onMonthMouseLeave={[Function]}
+          onMonthSelect={[Function]}
+          onPanelChange={[Function]}
+          onValueChange={[Function]}
+          prefixCls="rc-calendar"
+          setDisplayedValue={[Function]}
+          showTimePicker={false}
+          value={
+            Array [
+              "2017-03-28T22:00:00.000Z",
+            ]
+          }
+        >
+          <div
+            className="rc-calendar-header"
+          >
+            <div
+              style={
+                Object {
+                  "position": "relative",
+                }
+              }
+            >
+              <a
+                className="rc-calendar-prev-year-btn"
+                onClick={[Function]}
+                role="button"
+                title="Last year (Control + left)"
+              />
+              <a
+                className="rc-calendar-prev-month-btn"
+                onClick={[Function]}
+                role="button"
+                title="Previous month (PageUp)"
+              />
+              <a
+                className="rc-calendar-month-select"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+              >
+                March
+                 
+                2017
+              </a>
+              <a
+                className="rc-calendar-next-month-btn"
+                onClick={[Function]}
+                title="Next month (PageDown)"
+              />
+              <a
+                className="rc-calendar-next-year-btn"
+                onClick={[Function]}
+                title="Next year (Control + right)"
+              />
+            </div>
+          </div>
+        </CalendarHeader>
+        <div
+          className="rc-calendar-body"
+        >
+          <DateTable
+            disabledDate={[Function]}
+            displayedValue={"2017-03-28T22:00:00.000Z"}
+            locale={
+              Object {
+                "backToToday": "Back to today",
+                "clear": "Clear",
+                "dateFormat": "M/D/YYYY",
+                "dateSelect": "Select date",
+                "dateTimeFormat": "M/D/YYYY HH:mm:ss",
+                "dayFormat": "D",
+                "decadeSelect": "Choose a decade",
+                "month": "Month",
+                "monthBeforeYear": true,
+                "monthSelect": "Choose a month",
+                "nextCentury": "Next century",
+                "nextDecade": "Next decade",
+                "nextMonth": "Next month (PageDown)",
+                "nextYear": "Next year (Control + right)",
+                "now": "Now",
+                "ok": "Ok",
+                "previousCentury": "Last century",
+                "previousDecade": "Last decade",
+                "previousMonth": "Previous month (PageUp)",
+                "previousYear": "Last year (Control + left)",
+                "timeSelect": "Select time",
+                "today": "Today",
+                "year": "Year",
+                "yearFormat": "YYYY",
+                "yearSelect": "Choose a year",
+              }
+            }
+            multiple={true}
+            onSelect={[Function]}
+            prefixCls="rc-calendar"
+            selectedValue={
+              Array [
+                "2017-02-28T23:00:00.000Z",
+                "2017-03-01T23:00:00.000Z",
+                "2017-03-02T23:00:00.000Z",
+                "2017-03-03T23:00:00.000Z",
+                "2017-03-04T23:00:00.000Z",
+                "2017-03-05T23:00:00.000Z",
+                "2017-03-06T23:00:00.000Z",
+                "2017-03-07T23:00:00.000Z",
+                "2017-03-08T23:00:00.000Z",
+                "2017-03-09T23:00:00.000Z",
+                "2017-03-10T23:00:00.000Z",
+                "2017-03-11T23:00:00.000Z",
+                "2017-03-12T23:00:00.000Z",
+                "2017-03-13T23:00:00.000Z",
+                "2017-03-14T23:00:00.000Z",
+                "2017-03-15T23:00:00.000Z",
+                "2017-03-16T23:00:00.000Z",
+                "2017-03-17T23:00:00.000Z",
+                "2017-03-18T23:00:00.000Z",
+                "2017-03-19T23:00:00.000Z",
+                "2017-03-20T23:00:00.000Z",
+                "2017-03-21T23:00:00.000Z",
+                "2017-03-22T23:00:00.000Z",
+                "2017-03-23T23:00:00.000Z",
+                "2017-03-24T23:00:00.000Z",
+                "2017-03-25T23:00:00.000Z",
+                "2017-03-26T22:00:00.000Z",
+                "2017-03-27T22:00:00.000Z",
+                "2017-03-28T22:00:00.000Z",
+                "2017-03-29T22:00:00.000Z",
+                "2017-03-30T22:00:00.000Z",
+              ]
+            }
+            value={
+              Array [
+                "2017-03-28T22:00:00.000Z",
+              ]
+            }
+          >
+            <table
+              cellSpacing="0"
+              className="rc-calendar-table"
+              role="grid"
+            >
+              <DateTHead
+                disabledDate={[Function]}
+                displayedValue={"2017-03-28T22:00:00.000Z"}
+                locale={
+                  Object {
+                    "backToToday": "Back to today",
+                    "clear": "Clear",
+                    "dateFormat": "M/D/YYYY",
+                    "dateSelect": "Select date",
+                    "dateTimeFormat": "M/D/YYYY HH:mm:ss",
+                    "dayFormat": "D",
+                    "decadeSelect": "Choose a decade",
+                    "month": "Month",
+                    "monthBeforeYear": true,
+                    "monthSelect": "Choose a month",
+                    "nextCentury": "Next century",
+                    "nextDecade": "Next decade",
+                    "nextMonth": "Next month (PageDown)",
+                    "nextYear": "Next year (Control + right)",
+                    "now": "Now",
+                    "ok": "Ok",
+                    "previousCentury": "Last century",
+                    "previousDecade": "Last decade",
+                    "previousMonth": "Previous month (PageUp)",
+                    "previousYear": "Last year (Control + left)",
+                    "timeSelect": "Select time",
+                    "today": "Today",
+                    "year": "Year",
+                    "yearFormat": "YYYY",
+                    "yearSelect": "Choose a year",
+                  }
+                }
+                multiple={true}
+                onSelect={[Function]}
+                prefixCls="rc-calendar"
+                selectedValue={
+                  Array [
+                    "2017-02-28T23:00:00.000Z",
+                    "2017-03-01T23:00:00.000Z",
+                    "2017-03-02T23:00:00.000Z",
+                    "2017-03-03T23:00:00.000Z",
+                    "2017-03-04T23:00:00.000Z",
+                    "2017-03-05T23:00:00.000Z",
+                    "2017-03-06T23:00:00.000Z",
+                    "2017-03-07T23:00:00.000Z",
+                    "2017-03-08T23:00:00.000Z",
+                    "2017-03-09T23:00:00.000Z",
+                    "2017-03-10T23:00:00.000Z",
+                    "2017-03-11T23:00:00.000Z",
+                    "2017-03-12T23:00:00.000Z",
+                    "2017-03-13T23:00:00.000Z",
+                    "2017-03-14T23:00:00.000Z",
+                    "2017-03-15T23:00:00.000Z",
+                    "2017-03-16T23:00:00.000Z",
+                    "2017-03-17T23:00:00.000Z",
+                    "2017-03-18T23:00:00.000Z",
+                    "2017-03-19T23:00:00.000Z",
+                    "2017-03-20T23:00:00.000Z",
+                    "2017-03-21T23:00:00.000Z",
+                    "2017-03-22T23:00:00.000Z",
+                    "2017-03-23T23:00:00.000Z",
+                    "2017-03-24T23:00:00.000Z",
+                    "2017-03-25T23:00:00.000Z",
+                    "2017-03-26T22:00:00.000Z",
+                    "2017-03-27T22:00:00.000Z",
+                    "2017-03-28T22:00:00.000Z",
+                    "2017-03-29T22:00:00.000Z",
+                    "2017-03-30T22:00:00.000Z",
+                  ]
+                }
+                value={
+                  Array [
+                    "2017-03-28T22:00:00.000Z",
+                  ]
+                }
+              >
+                <thead>
+                  <tr
+                    role="row"
+                  >
+                    <th
+                      className="rc-calendar-column-header"
+                      key="0"
+                      role="columnheader"
+                      title="Sun"
+                    >
+                      <span
+                        className="rc-calendar-column-header-inner"
+                      >
+                        Su
+                      </span>
+                    </th>
+                    <th
+                      className="rc-calendar-column-header"
+                      key="1"
+                      role="columnheader"
+                      title="Mon"
+                    >
+                      <span
+                        className="rc-calendar-column-header-inner"
+                      >
+                        Mo
+                      </span>
+                    </th>
+                    <th
+                      className="rc-calendar-column-header"
+                      key="2"
+                      role="columnheader"
+                      title="Tue"
+                    >
+                      <span
+                        className="rc-calendar-column-header-inner"
+                      >
+                        Tu
+                      </span>
+                    </th>
+                    <th
+                      className="rc-calendar-column-header"
+                      key="3"
+                      role="columnheader"
+                      title="Wed"
+                    >
+                      <span
+                        className="rc-calendar-column-header-inner"
+                      >
+                        We
+                      </span>
+                    </th>
+                    <th
+                      className="rc-calendar-column-header"
+                      key="4"
+                      role="columnheader"
+                      title="Thu"
+                    >
+                      <span
+                        className="rc-calendar-column-header-inner"
+                      >
+                        Th
+                      </span>
+                    </th>
+                    <th
+                      className="rc-calendar-column-header"
+                      key="5"
+                      role="columnheader"
+                      title="Fri"
+                    >
+                      <span
+                        className="rc-calendar-column-header-inner"
+                      >
+                        Fr
+                      </span>
+                    </th>
+                    <th
+                      className="rc-calendar-column-header"
+                      key="6"
+                      role="columnheader"
+                      title="Sat"
+                    >
+                      <span
+                        className="rc-calendar-column-header-inner"
+                      >
+                        Sa
+                      </span>
+                    </th>
+                  </tr>
+                </thead>
+              </DateTHead>
+              <DateTBody
+                disabledDate={[Function]}
+                displayedValue={"2017-03-28T22:00:00.000Z"}
+                hoverValue={Array []}
+                locale={
+                  Object {
+                    "backToToday": "Back to today",
+                    "clear": "Clear",
+                    "dateFormat": "M/D/YYYY",
+                    "dateSelect": "Select date",
+                    "dateTimeFormat": "M/D/YYYY HH:mm:ss",
+                    "dayFormat": "D",
+                    "decadeSelect": "Choose a decade",
+                    "month": "Month",
+                    "monthBeforeYear": true,
+                    "monthSelect": "Choose a month",
+                    "nextCentury": "Next century",
+                    "nextDecade": "Next decade",
+                    "nextMonth": "Next month (PageDown)",
+                    "nextYear": "Next year (Control + right)",
+                    "now": "Now",
+                    "ok": "Ok",
+                    "previousCentury": "Last century",
+                    "previousDecade": "Last decade",
+                    "previousMonth": "Previous month (PageUp)",
+                    "previousYear": "Last year (Control + left)",
+                    "timeSelect": "Select time",
+                    "today": "Today",
+                    "year": "Year",
+                    "yearFormat": "YYYY",
+                    "yearSelect": "Choose a year",
+                  }
+                }
+                multiple={true}
+                onSelect={[Function]}
+                prefixCls="rc-calendar"
+                selectedValue={
+                  Array [
+                    "2017-02-28T23:00:00.000Z",
+                    "2017-03-01T23:00:00.000Z",
+                    "2017-03-02T23:00:00.000Z",
+                    "2017-03-03T23:00:00.000Z",
+                    "2017-03-04T23:00:00.000Z",
+                    "2017-03-05T23:00:00.000Z",
+                    "2017-03-06T23:00:00.000Z",
+                    "2017-03-07T23:00:00.000Z",
+                    "2017-03-08T23:00:00.000Z",
+                    "2017-03-09T23:00:00.000Z",
+                    "2017-03-10T23:00:00.000Z",
+                    "2017-03-11T23:00:00.000Z",
+                    "2017-03-12T23:00:00.000Z",
+                    "2017-03-13T23:00:00.000Z",
+                    "2017-03-14T23:00:00.000Z",
+                    "2017-03-15T23:00:00.000Z",
+                    "2017-03-16T23:00:00.000Z",
+                    "2017-03-17T23:00:00.000Z",
+                    "2017-03-18T23:00:00.000Z",
+                    "2017-03-19T23:00:00.000Z",
+                    "2017-03-20T23:00:00.000Z",
+                    "2017-03-21T23:00:00.000Z",
+                    "2017-03-22T23:00:00.000Z",
+                    "2017-03-23T23:00:00.000Z",
+                    "2017-03-24T23:00:00.000Z",
+                    "2017-03-25T23:00:00.000Z",
+                    "2017-03-26T22:00:00.000Z",
+                    "2017-03-27T22:00:00.000Z",
+                    "2017-03-28T22:00:00.000Z",
+                    "2017-03-29T22:00:00.000Z",
+                    "2017-03-30T22:00:00.000Z",
+                  ]
+                }
+                value={
+                  Array [
+                    "2017-03-28T22:00:00.000Z",
+                  ]
+                }
+              >
+                <tbody
+                  className="rc-calendar-tbody"
+                >
+                  <tr
+                    className=""
+                    key="0"
+                    role="row"
+                  >
+                    <td
+                      className="rc-calendar-cell rc-calendar-last-month-cell"
+                      key="0"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="February 26, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-1-26"
+                      >
+                        26
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-last-month-cell"
+                      key="1"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="February 27, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-1-27"
+                      >
+                        27
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-last-month-cell"
+                      key="2"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="February 28, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-1-28"
+                      >
+                        28
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="3"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 1, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-1"
+                      >
+                        1
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="4"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 2, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-2"
+                      >
+                        2
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="5"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 3, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-3"
+                      >
+                        3
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="6"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 4, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-4"
+                      >
+                        4
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    className=""
+                    key="1"
+                    role="row"
+                  >
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="7"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 5, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-5"
+                      >
+                        5
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="8"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 6, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-6"
+                      >
+                        6
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="9"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 7, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-7"
+                      >
+                        7
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="10"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 8, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-8"
+                      >
+                        8
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="11"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 9, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-9"
+                      >
+                        9
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="12"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 10, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-10"
+                      >
+                        10
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="13"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 11, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-11"
+                      >
+                        11
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    className=""
+                    key="2"
+                    role="row"
+                  >
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="14"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 12, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-12"
+                      >
+                        12
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="15"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 13, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-13"
+                      >
+                        13
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="16"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 14, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-14"
+                      >
+                        14
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="17"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 15, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-15"
+                      >
+                        15
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="18"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 16, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-16"
+                      >
+                        16
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="19"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 17, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-17"
+                      >
+                        17
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="20"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 18, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-18"
+                      >
+                        18
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    className=""
+                    key="3"
+                    role="row"
+                  >
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="21"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 19, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-19"
+                      >
+                        19
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="22"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 20, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-20"
+                      >
+                        20
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="23"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 21, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-21"
+                      >
+                        21
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="24"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 22, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-22"
+                      >
+                        22
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="25"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 23, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-23"
+                      >
+                        23
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="26"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 24, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-24"
+                      >
+                        24
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="27"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 25, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-25"
+                      >
+                        25
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    className="rc-calendar-current-week"
+                    key="4"
+                    role="row"
+                  >
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="28"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 26, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-26"
+                      >
+                        26
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="29"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 27, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-27"
+                      >
+                        27
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="30"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 28, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-28"
+                      >
+                        28
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-today rc-calendar-selected-date"
+                      key="31"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 29, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-29"
+                      >
+                        29
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="32"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 30, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-30"
+                      >
+                        30
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-selected-date"
+                      key="33"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="March 31, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-2-31"
+                      >
+                        31
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-next-month-btn-day"
+                      key="34"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="April 1, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-3-1"
+                      >
+                        1
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    className=""
+                    key="5"
+                    role="row"
+                  >
+                    <td
+                      className="rc-calendar-cell rc-calendar-next-month-btn-day"
+                      key="35"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="April 2, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-3-2"
+                      >
+                        2
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-next-month-btn-day"
+                      key="36"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="April 3, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-3-3"
+                      >
+                        3
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-next-month-btn-day"
+                      key="37"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="April 4, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-3-4"
+                      >
+                        4
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-next-month-btn-day"
+                      key="38"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="April 5, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-3-5"
+                      >
+                        5
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-next-month-btn-day"
+                      key="39"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="April 6, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-3-6"
+                      >
+                        6
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-next-month-btn-day"
+                      key="40"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="April 7, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-3-7"
+                      >
+                        7
+                      </div>
+                    </td>
+                    <td
+                      className="rc-calendar-cell rc-calendar-next-month-btn-day"
+                      key="41"
+                      onClick={[Function]}
+                      role="gridcell"
+                      title="April 8, 2017"
+                    >
+                      <div
+                        aria-disabled={false}
+                        aria-selected={false}
+                        className="rc-calendar-date"
+                        key="rc-calendar-2017-3-8"
+                      >
+                        8
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </DateTBody>
+            </table>
+          </DateTable>
+        </div>
+        <CalendarFooter
+          disabledDate={[Function]}
+          displayedValue={"2017-03-28T22:00:00.000Z"}
+          locale={
+            Object {
+              "backToToday": "Back to today",
+              "clear": "Clear",
+              "dateFormat": "M/D/YYYY",
+              "dateSelect": "Select date",
+              "dateTimeFormat": "M/D/YYYY HH:mm:ss",
+              "dayFormat": "D",
+              "decadeSelect": "Choose a decade",
+              "month": "Month",
+              "monthBeforeYear": true,
+              "monthSelect": "Choose a month",
+              "nextCentury": "Next century",
+              "nextDecade": "Next decade",
+              "nextMonth": "Next month (PageDown)",
+              "nextYear": "Next year (Control + right)",
+              "now": "Now",
+              "ok": "Ok",
+              "previousCentury": "Last century",
+              "previousDecade": "Last decade",
+              "previousMonth": "Previous month (PageUp)",
+              "previousYear": "Last year (Control + left)",
+              "timeSelect": "Select time",
+              "today": "Today",
+              "year": "Year",
+              "yearFormat": "YYYY",
+              "yearSelect": "Choose a year",
+            }
+          }
+          multiple={true}
+          okDisabled={false}
+          onCloseTimePicker={[Function]}
+          onOk={[Function]}
+          onOpenTimePicker={[Function]}
+          onSelect={[Function]}
+          onToday={[Function]}
+          prefixCls="rc-calendar"
+          renderFooter={[Function]}
+          selectedValue={
+            Array [
+              "2017-02-28T23:00:00.000Z",
+              "2017-03-01T23:00:00.000Z",
+              "2017-03-02T23:00:00.000Z",
+              "2017-03-03T23:00:00.000Z",
+              "2017-03-04T23:00:00.000Z",
+              "2017-03-05T23:00:00.000Z",
+              "2017-03-06T23:00:00.000Z",
+              "2017-03-07T23:00:00.000Z",
+              "2017-03-08T23:00:00.000Z",
+              "2017-03-09T23:00:00.000Z",
+              "2017-03-10T23:00:00.000Z",
+              "2017-03-11T23:00:00.000Z",
+              "2017-03-12T23:00:00.000Z",
+              "2017-03-13T23:00:00.000Z",
+              "2017-03-14T23:00:00.000Z",
+              "2017-03-15T23:00:00.000Z",
+              "2017-03-16T23:00:00.000Z",
+              "2017-03-17T23:00:00.000Z",
+              "2017-03-18T23:00:00.000Z",
+              "2017-03-19T23:00:00.000Z",
+              "2017-03-20T23:00:00.000Z",
+              "2017-03-21T23:00:00.000Z",
+              "2017-03-22T23:00:00.000Z",
+              "2017-03-23T23:00:00.000Z",
+              "2017-03-24T23:00:00.000Z",
+              "2017-03-25T23:00:00.000Z",
+              "2017-03-26T22:00:00.000Z",
+              "2017-03-27T22:00:00.000Z",
+              "2017-03-28T22:00:00.000Z",
+              "2017-03-29T22:00:00.000Z",
+              "2017-03-30T22:00:00.000Z",
+            ]
+          }
+          showDateInput={true}
+          showTimePicker={false}
+          showToday={true}
+          timePicker={null}
+          value={
+            Array [
+              "2017-03-28T22:00:00.000Z",
+            ]
+          }
+        >
+          <div
+            className="rc-calendar-footer"
+          >
+            <span
+              className="rc-calendar-footer-btn"
+            >
+              <TodayButton
+                disabledDate={[Function]}
+                displayedValue={"2017-03-28T22:00:00.000Z"}
+                key=".0"
+                locale={
+                  Object {
+                    "backToToday": "Back to today",
+                    "clear": "Clear",
+                    "dateFormat": "M/D/YYYY",
+                    "dateSelect": "Select date",
+                    "dateTimeFormat": "M/D/YYYY HH:mm:ss",
+                    "dayFormat": "D",
+                    "decadeSelect": "Choose a decade",
+                    "month": "Month",
+                    "monthBeforeYear": true,
+                    "monthSelect": "Choose a month",
+                    "nextCentury": "Next century",
+                    "nextDecade": "Next decade",
+                    "nextMonth": "Next month (PageDown)",
+                    "nextYear": "Next year (Control + right)",
+                    "now": "Now",
+                    "ok": "Ok",
+                    "previousCentury": "Last century",
+                    "previousDecade": "Last decade",
+                    "previousMonth": "Previous month (PageUp)",
+                    "previousYear": "Last year (Control + left)",
+                    "timeSelect": "Select time",
+                    "today": "Today",
+                    "year": "Year",
+                    "yearFormat": "YYYY",
+                    "yearSelect": "Choose a year",
+                  }
+                }
+                multiple={true}
+                okDisabled={false}
+                onCloseTimePicker={[Function]}
+                onOk={[Function]}
+                onOpenTimePicker={[Function]}
+                onSelect={[Function]}
+                onToday={[Function]}
+                prefixCls="rc-calendar"
+                renderFooter={[Function]}
+                selectedValue={
+                  Array [
+                    "2017-02-28T23:00:00.000Z",
+                    "2017-03-01T23:00:00.000Z",
+                    "2017-03-02T23:00:00.000Z",
+                    "2017-03-03T23:00:00.000Z",
+                    "2017-03-04T23:00:00.000Z",
+                    "2017-03-05T23:00:00.000Z",
+                    "2017-03-06T23:00:00.000Z",
+                    "2017-03-07T23:00:00.000Z",
+                    "2017-03-08T23:00:00.000Z",
+                    "2017-03-09T23:00:00.000Z",
+                    "2017-03-10T23:00:00.000Z",
+                    "2017-03-11T23:00:00.000Z",
+                    "2017-03-12T23:00:00.000Z",
+                    "2017-03-13T23:00:00.000Z",
+                    "2017-03-14T23:00:00.000Z",
+                    "2017-03-15T23:00:00.000Z",
+                    "2017-03-16T23:00:00.000Z",
+                    "2017-03-17T23:00:00.000Z",
+                    "2017-03-18T23:00:00.000Z",
+                    "2017-03-19T23:00:00.000Z",
+                    "2017-03-20T23:00:00.000Z",
+                    "2017-03-21T23:00:00.000Z",
+                    "2017-03-22T23:00:00.000Z",
+                    "2017-03-23T23:00:00.000Z",
+                    "2017-03-24T23:00:00.000Z",
+                    "2017-03-25T23:00:00.000Z",
+                    "2017-03-26T22:00:00.000Z",
+                    "2017-03-27T22:00:00.000Z",
+                    "2017-03-28T22:00:00.000Z",
+                    "2017-03-29T22:00:00.000Z",
+                    "2017-03-30T22:00:00.000Z",
+                  ]
+                }
+                showDateInput={true}
+                showTimePicker={false}
+                showToday={true}
+                timePicker={null}
+                value={
+                  Array [
+                    "2017-03-28T22:00:00.000Z",
+                  ]
+                }
+              >
+                <a
+                  className="rc-calendar-today-btn "
+                  onClick={[Function]}
+                  role="button"
+                  title="March 29, 2017"
+                >
+                  Today
+                </a>
+              </TodayButton>
+            </span>
+          </div>
+        </CalendarFooter>
+      </div>
+    </div>
+  </div>
+</Calendar>
+`;
+
 exports[`Calendar render render correctly 1`] = `
 <div
   class="rc-calendar"
@@ -3299,6 +6227,1536 @@ exports[`Calendar render render correctly 2`] = `
               </td>
               <td
                 class="rc-calendar-cell"
+                role="gridcell"
+                title="March 30, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  30
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 31, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  31
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell rc-calendar-next-month-btn-day"
+                role="gridcell"
+                title="April 1, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  1
+                </div>
+              </td>
+            </tr>
+            <tr
+              class=""
+              role="row"
+            >
+              <td
+                class="rc-calendar-cell rc-calendar-next-month-btn-day"
+                role="gridcell"
+                title="April 2, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  2
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell rc-calendar-next-month-btn-day"
+                role="gridcell"
+                title="April 3, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  3
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell rc-calendar-next-month-btn-day"
+                role="gridcell"
+                title="April 4, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  4
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell rc-calendar-next-month-btn-day"
+                role="gridcell"
+                title="April 5, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  5
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell rc-calendar-next-month-btn-day"
+                role="gridcell"
+                title="April 6, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  6
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell rc-calendar-next-month-btn-day"
+                role="gridcell"
+                title="April 7, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  7
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell rc-calendar-next-month-btn-day"
+                role="gridcell"
+                title="April 8, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  8
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div
+        class="rc-calendar-footer"
+      >
+        <span
+          class="rc-calendar-footer-btn"
+        >
+          <a
+            class="rc-calendar-today-btn "
+            role="button"
+            title="March 29, 2017"
+          >
+            Today
+          </a>
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Calendar render render correctly with multiple selected dates for defaultSelectedValue 1`] = `
+<div
+  class="rc-calendar"
+  tabindex="0"
+>
+  <div
+    class="rc-calendar-panel"
+  >
+    <div
+      class="rc-calendar-input-wrap"
+    >
+      <div
+        class="rc-calendar-date-input-wrap"
+      >
+        <input
+          class="rc-calendar-input "
+          value="3/29/2017, 3/30/2017"
+        />
+      </div>
+      <a
+        class="rc-calendar-clear-btn"
+        role="button"
+        title="Clear"
+      />
+    </div>
+    <div
+      class="rc-calendar-date-panel"
+    >
+      <div
+        class="rc-calendar-header"
+      >
+        <div
+          style="position:relative"
+        >
+          <a
+            class="rc-calendar-prev-year-btn"
+            role="button"
+            title="Last year (Control + left)"
+          />
+          <a
+            class="rc-calendar-prev-month-btn"
+            role="button"
+            title="Previous month (PageUp)"
+          />
+          <span
+            class="rc-calendar-my-select"
+          >
+            <a
+              class="rc-calendar-month-select"
+              role="button"
+              title="Choose a month"
+            >
+              Mar
+            </a>
+            <a
+              class="rc-calendar-year-select"
+              role="button"
+              title="Choose a year"
+            >
+              2017
+            </a>
+          </span>
+          <a
+            class="rc-calendar-next-month-btn"
+            title="Next month (PageDown)"
+          />
+          <a
+            class="rc-calendar-next-year-btn"
+            title="Next year (Control + right)"
+          />
+        </div>
+      </div>
+      <div
+        class="rc-calendar-body"
+      >
+        <table
+          cellspacing="0"
+          class="rc-calendar-table"
+          role="grid"
+        >
+          <thead>
+            <tr
+              role="row"
+            >
+              <th
+                class="rc-calendar-column-header"
+                role="columnheader"
+                title="Sun"
+              >
+                <span
+                  class="rc-calendar-column-header-inner"
+                >
+                  Su
+                </span>
+              </th>
+              <th
+                class="rc-calendar-column-header"
+                role="columnheader"
+                title="Mon"
+              >
+                <span
+                  class="rc-calendar-column-header-inner"
+                >
+                  Mo
+                </span>
+              </th>
+              <th
+                class="rc-calendar-column-header"
+                role="columnheader"
+                title="Tue"
+              >
+                <span
+                  class="rc-calendar-column-header-inner"
+                >
+                  Tu
+                </span>
+              </th>
+              <th
+                class="rc-calendar-column-header"
+                role="columnheader"
+                title="Wed"
+              >
+                <span
+                  class="rc-calendar-column-header-inner"
+                >
+                  We
+                </span>
+              </th>
+              <th
+                class="rc-calendar-column-header"
+                role="columnheader"
+                title="Thu"
+              >
+                <span
+                  class="rc-calendar-column-header-inner"
+                >
+                  Th
+                </span>
+              </th>
+              <th
+                class="rc-calendar-column-header"
+                role="columnheader"
+                title="Fri"
+              >
+                <span
+                  class="rc-calendar-column-header-inner"
+                >
+                  Fr
+                </span>
+              </th>
+              <th
+                class="rc-calendar-column-header"
+                role="columnheader"
+                title="Sat"
+              >
+                <span
+                  class="rc-calendar-column-header-inner"
+                >
+                  Sa
+                </span>
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            class="rc-calendar-tbody"
+          >
+            <tr
+              class=""
+              role="row"
+            >
+              <td
+                class="rc-calendar-cell rc-calendar-last-month-cell"
+                role="gridcell"
+                title="February 26, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  26
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell rc-calendar-last-month-cell"
+                role="gridcell"
+                title="February 27, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  27
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell rc-calendar-last-month-cell"
+                role="gridcell"
+                title="February 28, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  28
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 1, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  1
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 2, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  2
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 3, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  3
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 4, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  4
+                </div>
+              </td>
+            </tr>
+            <tr
+              class=""
+              role="row"
+            >
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 5, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  5
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 6, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  6
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 7, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  7
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 8, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  8
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 9, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  9
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 10, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  10
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 11, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  11
+                </div>
+              </td>
+            </tr>
+            <tr
+              class=""
+              role="row"
+            >
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 12, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  12
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 13, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  13
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 14, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  14
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 15, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  15
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 16, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  16
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 17, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  17
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 18, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  18
+                </div>
+              </td>
+            </tr>
+            <tr
+              class=""
+              role="row"
+            >
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 19, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  19
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 20, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  20
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 21, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  21
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 22, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  22
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 23, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  23
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 24, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  24
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 25, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  25
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="rc-calendar-current-week"
+              role="row"
+            >
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 26, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  26
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 27, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  27
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 28, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  28
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell rc-calendar-today rc-calendar-selected-date"
+                role="gridcell"
+                title="March 29, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  29
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell rc-calendar-selected-date"
+                role="gridcell"
+                title="March 30, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  30
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 31, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  31
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell rc-calendar-next-month-btn-day"
+                role="gridcell"
+                title="April 1, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  1
+                </div>
+              </td>
+            </tr>
+            <tr
+              class=""
+              role="row"
+            >
+              <td
+                class="rc-calendar-cell rc-calendar-next-month-btn-day"
+                role="gridcell"
+                title="April 2, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  2
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell rc-calendar-next-month-btn-day"
+                role="gridcell"
+                title="April 3, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  3
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell rc-calendar-next-month-btn-day"
+                role="gridcell"
+                title="April 4, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  4
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell rc-calendar-next-month-btn-day"
+                role="gridcell"
+                title="April 5, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  5
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell rc-calendar-next-month-btn-day"
+                role="gridcell"
+                title="April 6, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  6
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell rc-calendar-next-month-btn-day"
+                role="gridcell"
+                title="April 7, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  7
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell rc-calendar-next-month-btn-day"
+                role="gridcell"
+                title="April 8, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  8
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div
+        class="rc-calendar-footer"
+      >
+        <span
+          class="rc-calendar-footer-btn"
+        >
+          <a
+            class="rc-calendar-today-btn "
+            role="button"
+            title="March 29, 2017"
+          >
+            Today
+          </a>
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Calendar render render correctly with multiple selected dates for selectedValue 1`] = `
+<div
+  class="rc-calendar"
+  tabindex="0"
+>
+  <div
+    class="rc-calendar-panel"
+  >
+    <div
+      class="rc-calendar-input-wrap"
+    >
+      <div
+        class="rc-calendar-date-input-wrap"
+      >
+        <input
+          class="rc-calendar-input "
+          value="3/29/2017, 3/30/2017"
+        />
+      </div>
+      <a
+        class="rc-calendar-clear-btn"
+        role="button"
+        title="Clear"
+      />
+    </div>
+    <div
+      class="rc-calendar-date-panel"
+    >
+      <div
+        class="rc-calendar-header"
+      >
+        <div
+          style="position:relative"
+        >
+          <a
+            class="rc-calendar-prev-year-btn"
+            role="button"
+            title="Last year (Control + left)"
+          />
+          <a
+            class="rc-calendar-prev-month-btn"
+            role="button"
+            title="Previous month (PageUp)"
+          />
+          <span
+            class="rc-calendar-my-select"
+          >
+            <a
+              class="rc-calendar-month-select"
+              role="button"
+              title="Choose a month"
+            >
+              Mar
+            </a>
+            <a
+              class="rc-calendar-year-select"
+              role="button"
+              title="Choose a year"
+            >
+              2017
+            </a>
+          </span>
+          <a
+            class="rc-calendar-next-month-btn"
+            title="Next month (PageDown)"
+          />
+          <a
+            class="rc-calendar-next-year-btn"
+            title="Next year (Control + right)"
+          />
+        </div>
+      </div>
+      <div
+        class="rc-calendar-body"
+      >
+        <table
+          cellspacing="0"
+          class="rc-calendar-table"
+          role="grid"
+        >
+          <thead>
+            <tr
+              role="row"
+            >
+              <th
+                class="rc-calendar-column-header"
+                role="columnheader"
+                title="Sun"
+              >
+                <span
+                  class="rc-calendar-column-header-inner"
+                >
+                  Su
+                </span>
+              </th>
+              <th
+                class="rc-calendar-column-header"
+                role="columnheader"
+                title="Mon"
+              >
+                <span
+                  class="rc-calendar-column-header-inner"
+                >
+                  Mo
+                </span>
+              </th>
+              <th
+                class="rc-calendar-column-header"
+                role="columnheader"
+                title="Tue"
+              >
+                <span
+                  class="rc-calendar-column-header-inner"
+                >
+                  Tu
+                </span>
+              </th>
+              <th
+                class="rc-calendar-column-header"
+                role="columnheader"
+                title="Wed"
+              >
+                <span
+                  class="rc-calendar-column-header-inner"
+                >
+                  We
+                </span>
+              </th>
+              <th
+                class="rc-calendar-column-header"
+                role="columnheader"
+                title="Thu"
+              >
+                <span
+                  class="rc-calendar-column-header-inner"
+                >
+                  Th
+                </span>
+              </th>
+              <th
+                class="rc-calendar-column-header"
+                role="columnheader"
+                title="Fri"
+              >
+                <span
+                  class="rc-calendar-column-header-inner"
+                >
+                  Fr
+                </span>
+              </th>
+              <th
+                class="rc-calendar-column-header"
+                role="columnheader"
+                title="Sat"
+              >
+                <span
+                  class="rc-calendar-column-header-inner"
+                >
+                  Sa
+                </span>
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            class="rc-calendar-tbody"
+          >
+            <tr
+              class=""
+              role="row"
+            >
+              <td
+                class="rc-calendar-cell rc-calendar-last-month-cell"
+                role="gridcell"
+                title="February 26, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  26
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell rc-calendar-last-month-cell"
+                role="gridcell"
+                title="February 27, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  27
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell rc-calendar-last-month-cell"
+                role="gridcell"
+                title="February 28, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  28
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 1, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  1
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 2, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  2
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 3, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  3
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 4, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  4
+                </div>
+              </td>
+            </tr>
+            <tr
+              class=""
+              role="row"
+            >
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 5, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  5
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 6, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  6
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 7, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  7
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 8, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  8
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 9, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  9
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 10, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  10
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 11, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  11
+                </div>
+              </td>
+            </tr>
+            <tr
+              class=""
+              role="row"
+            >
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 12, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  12
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 13, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  13
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 14, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  14
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 15, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  15
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 16, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  16
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 17, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  17
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 18, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  18
+                </div>
+              </td>
+            </tr>
+            <tr
+              class=""
+              role="row"
+            >
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 19, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  19
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 20, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  20
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 21, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  21
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 22, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  22
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 23, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  23
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 24, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  24
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 25, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  25
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="rc-calendar-current-week"
+              role="row"
+            >
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 26, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  26
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 27, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  27
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell"
+                role="gridcell"
+                title="March 28, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  28
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell rc-calendar-today rc-calendar-selected-date"
+                role="gridcell"
+                title="March 29, 2017"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="rc-calendar-date"
+                >
+                  29
+                </div>
+              </td>
+              <td
+                class="rc-calendar-cell rc-calendar-selected-date"
                 role="gridcell"
                 title="March 30, 2017"
               >


### PR DESCRIPTION
The calendar should allow selecting multiple dates independently, not only single values or ranges. Also we want to make it possible to select all days of one weekday or an entire month.

New props:

<table class="table table-bordered table-striped">
    <thead>
    <tr>
        <th style="width: 100px;">name</th>
        <th style="width: 50px;">type</th>
        <th style="width: 50px;">default</th>
        <th>description</th>
    </tr>
    </thead>
<tbody>
<tr>
          <td>multiple</td>
          <td>Boolean</td>
          <td>false</td>
          <td>make it possible to select multiple values</td>
        </tr>
        <tr>
          <td>selectWeekDays</td>
          <td>Boolean</td>
          <td>false</td>
          <td>make it possible to select all days of one weekday, e.g. all sundays</td>
        </tr>
        <tr>
          <td>selectMonths</td>
          <td>Boolean</td>
          <td>false</td>
          <td>make it possible to select an entire month</td>
        </tr>
</tbody>
</table>