### PR TITLE
feat: add close function to programmatically close the datepicker

### DIFF
--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -173,6 +173,10 @@ const Calendar = createReactClass({
     }
   },
 
+  close() {
+    this.props.close();
+  },
+
   onDateInputChange(value) {
     this.onSelect(value, {
       source: 'dateInput',

--- a/src/Picker.jsx
+++ b/src/Picker.jsx
@@ -149,6 +149,7 @@ const Picker = createReactClass({
       onOk: createChainedFunction(calendarProps.onOk, this.onCalendarOk),
       onSelect: createChainedFunction(calendarProps.onSelect, this.onCalendarSelect),
       onClear: createChainedFunction(calendarProps.onClear, this.onCalendarClear),
+      close: this.close,
     };
 
     return React.cloneElement(props.calendar, extraProps);


### PR DESCRIPTION
Add `close()` so the datepicker can be programmatically closed calling `ref.close()` without checking if the dates are correct like in `ref.onOk()`.

Maybe there is an easier solution to close the datepicker from outside without adding this function, then please tell me. 🙂 