### PR TITLE
fix: open prop undefined should not break opening

### DIFF
--- a/src/Picker.jsx
+++ b/src/Picker.jsx
@@ -55,7 +55,7 @@ const Picker = createReactClass({
   getInitialState() {
     const props = this.props;
     let open;
-    if ('open' in props) {
+    if ('open' in props && props.open !== undefined) {
       open = props.open;
     } else {
       open = props.defaultOpen;
@@ -157,7 +157,7 @@ const Picker = createReactClass({
   setOpen(open, callback) {
     const { onOpenChange } = this.props;
     if (this.state.open !== open) {
-      if (!('open' in this.props)) {
+      if (!('open' in this.props) || this.props.open === undefined) {
         this.setState({
           open,
         }, callback);


### PR DESCRIPTION
When you pass `open={undefined}`, you are not able to open the picker anymore by clicking.

I want to add a check for `undefined` in two places, so it doesn't break.

In my use-case I want to close the picker programmatically, but the rest should work like before with click. So I set `open` to `false` to close and set it immediately back to `undefined` then.