### PR TITLE
Max height moved from <ul> to parent div.

### DIFF
--- a/assets/common/Calendar.less
+++ b/assets/common/Calendar.less
@@ -31,9 +31,7 @@
         }
         &-select {
           width: 84px;
-          ul {
-            max-height: 217px;
-          }
+          max-height: 217px;
           li {
             text-align: center;
             padding: 0;


### PR DESCRIPTION
When rendering the TimePickerPanel inside the Calendar component, the height of the panel is actually smaller than the calendar! The current solution at using `max-height`in the `ul` component was not doing anything. I moved it to the div parent, which seemed to have fixed the problem.