### PR TITLE
Re-implement support for dateRender prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,6 +31,7 @@ export interface Props {
   onPanelChange?: (date: Moment, mode: Mode) => void;
   disabledDate?: (current: Moment) => boolean;
   disabledTime?: (current: Moment) => object;
+  dateRender?:(current: Moment, value: Moment) => React.Node;
   renderFooter?: () => React.ReactNode;
   renderSidebar?: () => React.ReactNode;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -31,7 +31,7 @@ export interface Props {
   onPanelChange?: (date: Moment, mode: Mode) => void;
   disabledDate?: (current: Moment) => boolean;
   disabledTime?: (current: Moment) => object;
-  dateRender?:(current: Moment, value: Moment) => React.Node;
+  dateRender?: (current: Moment, value: Moment) => React.ReactNode;
   renderFooter?: () => React.ReactNode;
   renderSidebar?: () => React.ReactNode;
 }

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -39,6 +39,7 @@ const Calendar = createReactClass({
     onPanelChange: PropTypes.func,
     disabledDate: PropTypes.func,
     disabledTime: PropTypes.any,
+    dateRender: PropTypes.func,
     renderFooter: PropTypes.func,
     renderSidebar: PropTypes.func,
   },


### PR DESCRIPTION
Code already supports this feature, but it was recently removed. We recently upgraded to React 16 and Ant 3.x, which ended up updating react-component as a dependency, and we discovered this prop was removed.