### PR TITLE
use value instead of default value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,3 @@ env:
   matrix:
   - TEST_TYPE=lint
   - TEST_TYPE=test
-  - TEST_TYPE=types

--- a/src/calendar/CalendarHeader.jsx
+++ b/src/calendar/CalendarHeader.jsx
@@ -149,7 +149,7 @@ const CalendarHeader = createReactClass({
       panel = (
         <MonthPanel
           locale={locale}
-          defaultValue={value}
+          value={value}
           rootPrefixCls={prefixCls}
           onSelect={this.onMonthSelect}
           onYearPanelShow={() => this.showYearPanel('month')}
@@ -163,7 +163,7 @@ const CalendarHeader = createReactClass({
       panel = (
         <YearPanel
           locale={locale}
-          defaultValue={value}
+          value={value}
           rootPrefixCls={prefixCls}
           onSelect={this.onYearSelect}
           onDecadePanelShow={this.showDecadePanel}
@@ -174,7 +174,7 @@ const CalendarHeader = createReactClass({
       panel = (
         <DecadePanel
           locale={locale}
-          defaultValue={value}
+          value={value}
           rootPrefixCls={prefixCls}
           onSelect={this.onDecadeSelect}
         />


### PR DESCRIPTION
以前从 `value` 改成了 `defaultValue`： https://github.com/react-component/calendar/commit/a45f543a008f68f3392b055f6bb1ef0f39bc628c#diff-bf02fe778785099e5c2bea1895305609R76

但是看起来设置成 `value` 没什么影响，帮我验证一下...

ref:
* https://github.com/ant-design/ant-design/issues/10758
* https://github.com/ant-design/ant-design/issues/9334