### PR TITLE
Add 'format' type to definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,7 @@ export interface Props {
   selectedValue?: Moment;
   mode?: Mode;
   locale?: object;
+  format?: string;
   showDateInput?: boolean;
   showWeekNumber?: boolean;
   showToday?: boolean;


### PR DESCRIPTION
I have type error in `format` attribute of `Calendar` component due to definition missing:

```
$ tsc -p tsconfig.json --noEmit
src/components/shared/datetime_picker/datetime_picker.tsx:64:9 - error TS2339: Property 'format' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<ReactCalendar> & Readonly<{ children?: ReactNode; }> & Readonly<Props>'.

64         format='YYYY-MM-DD'
```