### PR TITLE
'format' attribute accept array of string in type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ export interface Props {
   selectedValue?: Moment;
   mode?: Mode;
   locale?: object;
-  format?: string;
+  format?: string | string[];
   showDateInput?: boolean;
   showWeekNumber?: boolean;
   showToday?: boolean;


### PR DESCRIPTION
Sorry, previous PR (https://github.com/react-component/calendar/pull/473) missed array of string.