### PR TITLE
Close calendar picker on blur

### DIFF
--- a/examples/antd-calendar.js
+++ b/examples/antd-calendar.js
@@ -73,10 +73,13 @@ class Demo extends React.Component {
   constructor(props) {
     super(props);
 
+    this.calendarContainerRef = React.createRef();
+
     this.state = {
       showTime: true,
       showDateInput: true,
       disabled: false,
+      open: false,
       value: props.defaultValue,
     };
   }
@@ -100,6 +103,20 @@ class Demo extends React.Component {
     });
   }
 
+  onOpenChange = (open) => {
+    this.setState({
+      open,
+    });
+  }
+
+  onReadOnlyFocus = () => {
+    this.setState({
+      open: true,
+    });
+  }
+
+  getCalendarContainer = () => this.calendarContainerRef.current;
+
   toggleDisabled = () => {
     this.setState({
       disabled: !this.state.disabled,
@@ -110,7 +127,7 @@ class Demo extends React.Component {
     const state = this.state;
     const calendar = (<Calendar
       locale={cn ? zhCN : enUS}
-      style={{ zIndex: 1000 }}
+      style={{ zIndex: 1001 }}
       dateInputPlaceholder="please input"
       format={getFormat(state.showTime)}
       disabledTime={state.showTime ? disabledTime : null}
@@ -118,6 +135,7 @@ class Demo extends React.Component {
       defaultValue={this.props.defaultCalendarValue}
       showDateInput={state.showDateInput}
       disabledDate={disabledDate}
+      focusablePanel={false}
     />);
     return (<div style={{ width: 400, margin: 20 }}>
       <div style={{ marginBottom: 10 }}>
@@ -161,11 +179,15 @@ class Demo extends React.Component {
           calendar={calendar}
           value={state.value}
           onChange={this.onChange}
+          getCalendarContainer={this.getCalendarContainer}
+          onOpenChange={this.onOpenChange}
+          open={state.open}
+          style={{ zIndex: 1001 }}
         >
           {
             ({ value }) => {
               return (
-                <span tabIndex="0">
+                <span tabIndex="0" onFocus={this.onReadOnlyFocus}>
                   <input
                     placeholder="please select"
                     style={{ width: 250 }}
@@ -175,6 +197,7 @@ class Demo extends React.Component {
                     className="ant-calendar-picker-input ant-input"
                     value={value && value.format(getFormat(state.showTime)) || ''}
                   />
+                  <div ref={this.calendarContainerRef} />
                 </span>
               );
             }

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -53,6 +53,7 @@ class Calendar extends React.Component {
     renderSidebar: PropTypes.func,
     clearIcon: PropTypes.node,
     focusablePanel: PropTypes.bool,
+    onBlur: PropTypes.func,
   }
 
   static defaultProps = {
@@ -65,7 +66,6 @@ class Calendar extends React.Component {
     onPanelChange: noop,
     focusablePanel: true,
   }
-
 
   constructor(props) {
     super(props);
@@ -93,11 +93,6 @@ class Calendar extends React.Component {
 
   onKeyDown = (event) => {
     if (event.target.nodeName.toLowerCase() === 'input') {
-      if (event.keyCode === KeyCode.TAB) {
-        this.props.onKeyDown(event);
-        return 1;
-      }
-
       return undefined;
     }
     const keyCode = event.keyCode;
@@ -206,6 +201,23 @@ class Calendar extends React.Component {
     this.onSelect(now, {
       source: 'todayButton',
     });
+  }
+
+  onBlur = (event) => {
+    const dateInput = DateInput.getInstance();
+    const rootInstance = this.rootInstance;
+
+    setTimeout(() => {
+      if (!rootInstance || rootInstance.contains(document.activeElement) ||
+      (dateInput && dateInput.contains(document.activeElement))) {
+        // focused element is still part of Calendar
+        return;
+      }
+
+      if (this.props.onBlur) {
+        this.props.onBlur(event);
+      }
+    }, 0);
   }
 
   static getDerivedStateFromProps(nextProps, state) {

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -93,6 +93,11 @@ class Calendar extends React.Component {
 
   onKeyDown = (event) => {
     if (event.target.nodeName.toLowerCase() === 'input') {
+      if (event.keyCode === KeyCode.TAB) {
+        this.props.onKeyDown(event);
+        return 1;
+      }
+
       return undefined;
     }
     const keyCode = event.keyCode;

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -204,10 +204,10 @@ class Calendar extends React.Component {
   }
 
   onBlur = (event) => {
-    const dateInput = DateInput.getInstance();
-    const rootInstance = this.rootInstance;
-
     setTimeout(() => {
+      const dateInput = DateInput.getInstance();
+      const rootInstance = this.rootInstance;
+
       if (!rootInstance || rootInstance.contains(document.activeElement) ||
       (dateInput && dateInput.contains(document.activeElement))) {
         // focused element is still part of Calendar

--- a/src/Picker.jsx
+++ b/src/Picker.jsx
@@ -38,6 +38,7 @@ class Picker extends React.Component {
       PropTypes.array,
     ]),
     align: PropTypes.object,
+    onBlur: PropTypes.func,
   }
 
   static defaultProps = {
@@ -48,6 +49,7 @@ class Picker extends React.Component {
     defaultOpen: false,
     onChange: noop,
     onOpenChange: noop,
+    onBlur: noop,
   }
 
   constructor(props) {
@@ -83,8 +85,6 @@ class Picker extends React.Component {
     if (event.keyCode === KeyCode.ESC) {
       event.stopPropagation();
       this.close(this.focus);
-    } else if (event.keyCode === KeyCode.TAB && !this.props.calendar.props.focusablePanel) {
-      this.close();
     }
   }
 
@@ -120,6 +120,10 @@ class Picker extends React.Component {
     this.close(this.focus);
   }
 
+  onCalendarBlur = () => {
+    this.setOpen(false);
+  }
+
   onVisibleChange = (open) => {
     this.setOpen(open);
   }
@@ -150,6 +154,7 @@ class Picker extends React.Component {
       onOk: createChainedFunction(calendarProps.onOk, this.onCalendarOk),
       onSelect: createChainedFunction(calendarProps.onSelect, this.onCalendarSelect),
       onClear: createChainedFunction(calendarProps.onClear, this.onCalendarClear),
+      onBlur: createChainedFunction(calendarProps.onBlur, this.onCalendarBlur),
     };
 
     return React.cloneElement(props.calendar, extraProps);

--- a/src/Picker.jsx
+++ b/src/Picker.jsx
@@ -83,6 +83,8 @@ class Picker extends React.Component {
     if (event.keyCode === KeyCode.ESC) {
       event.stopPropagation();
       this.close(this.focus);
+    } else if (event.keyCode === KeyCode.TAB && !this.props.calendar.props.focusablePanel) {
+      this.close();
     }
   }
 

--- a/src/mixin/CalendarMixin.js
+++ b/src/mixin/CalendarMixin.js
@@ -76,6 +76,7 @@ export const calendarMixinWrapper = ComposeComponent => class extends ComposeCom
         style={this.props.style}
         tabIndex="0"
         onKeyDown={this.onKeyDown}
+        onBlur={this.onBlur}
       >
         {newProps.children}
       </div>

--- a/tests/Picker.spec.jsx
+++ b/tests/Picker.spec.jsx
@@ -33,7 +33,7 @@ describe('DatePicker', () => {
     />);
   }
 
-  function renderPicker(props, calendarProps) {
+  function renderPicker(props, calendarProps, options) {
     return mount(
       <DatePicker
         calendar={
@@ -48,7 +48,8 @@ describe('DatePicker', () => {
         {...props}
       >
         {renderOne}
-      </DatePicker>
+      </DatePicker>,
+        options
     );
   }
 
@@ -202,13 +203,75 @@ describe('DatePicker', () => {
     expect(picker.state().open).toBe(false);
   });
 
-  it('close on Tab of DateInput when panel is not focusable', () => {
-    const picker = renderPicker({ value: moment() }, { focusablePanel: false });
-    picker.find('.rc-calendar-picker-input').simulate('click');
-    picker.find('.rc-calendar-input').simulate('keyDown', {
-      keyCode: keyCode.TAB,
+  describe('on picker blur', () => {
+    let container;
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      container = document.createElement('div');
+      container.setAttribute('tabindex', 0);
+      document.body.appendChild(container);
     });
-    expect(picker.state().open).toBe(false);
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('close panel when focus is outside of picker', () => {
+      const picker = renderPicker({ value: moment() }, undefined, {
+        attachTo: container,
+      });
+      picker.find('.rc-calendar-picker-input').simulate('click');
+
+      jest.runAllTimers();
+      container.focus();
+      jest.runAllTimers();
+      expect(picker.state().open).toBe(false);
+    });
+
+    it('call onBlur when focus is outside of picker', () => {
+      const handleOnBlur = jest.fn();
+      const picker = renderPicker({ value: moment() }, { onBlur: handleOnBlur }, {
+        attachTo: container,
+      });
+
+      picker.find('.rc-calendar-picker-input').simulate('click');
+      jest.runAllTimers();
+      container.focus();
+      jest.runAllTimers();
+      expect(handleOnBlur).toBeCalled();
+    });
+
+    it('keep panel opened when clicking on calendar next month', () => {
+      const picker = renderPicker({ value: moment() }, undefined, {
+        attachTo: container,
+      });
+
+      picker.find('.rc-calendar-picker-input').simulate('click');
+
+      jest.runAllTimers();
+      const day = picker.find('.rc-calendar-next-month-btn');
+      day.simulate('click');
+      jest.runAllTimers();
+
+      expect(picker.state().open).toBe(true);
+    });
+
+    it('does not call onBlur when clicking on calendar next month', () => {
+      const handleOnBlur = jest.fn();
+      const picker = renderPicker({ value: moment() }, { onBlur: handleOnBlur }, {
+        attachTo: container,
+      });
+
+      picker.find('.rc-calendar-picker-input').simulate('click');
+      jest.runAllTimers();
+
+      const day = picker.find('.rc-calendar-next-month-btn');
+      day.simulate('click');
+      jest.runAllTimers();
+
+      expect(handleOnBlur).not.toBeCalled();
+    });
   });
 
   it('auto focuses the calendar input when opening', () => {

--- a/tests/Picker.spec.jsx
+++ b/tests/Picker.spec.jsx
@@ -202,6 +202,15 @@ describe('DatePicker', () => {
     expect(picker.state().open).toBe(false);
   });
 
+  it('close on Tab of DateInput when panel is not focusable', () => {
+    const picker = renderPicker({ value: moment() }, { focusablePanel: false });
+    picker.find('.rc-calendar-picker-input').simulate('click');
+    picker.find('.rc-calendar-input').simulate('keyDown', {
+      keyCode: keyCode.TAB,
+    });
+    expect(picker.state().open).toBe(false);
+  });
+
   it('auto focuses the calendar input when opening', () => {
     jest.useFakeTimers();
     const picker = renderPicker({ value: moment() });


### PR DESCRIPTION
Currently, when using a date picker with a calendar such as  `<Calendar showDateInput={true} focusablePanel={false}/>`, pressing *Tab* from the date input keeps the calendar open.

With this pull request, it would instead close the calendar and let the browser focus the next element.

See the updated `antd-calendar` picker example where tabbing in and out of the picker is seamless.

![tabbing_datepicker](https://user-images.githubusercontent.com/1916218/52164196-4c67c900-2739-11e9-980b-981411b00598.gif)
