### PR TITLE
Fix MonthPicker keyboard change not response

### DIFF
--- a/src/month/MonthPanel.jsx
+++ b/src/month/MonthPanel.jsx
@@ -44,9 +44,9 @@ class MonthPanel extends React.Component {
   static getDerivedStateFromProps(nextProps) {
     let newState = {};
 
-    if ('value' in nextProps) {
+    if ('defaultValue' in nextProps) {
       newState = {
-        value: nextProps.value,
+        value: nextProps.defaultValue,
       };
     }
 

--- a/tests/MonthCalendar.spec.js
+++ b/tests/MonthCalendar.spec.js
@@ -96,6 +96,10 @@ describe('MonthCalendar', () => {
       });
       expect(wrapper.state().value.month()).toBe(4);
       expect(wrapper.state().value.year()).toBe(2018);
+      const selectedValues = wrapper.find('.rc-calendar-month-panel-year-select-content');
+      for (let i = 0; i < selectedValues.length; i += 1) {
+        expect(selectedValues.at(i).text()).toBe('2018');
+      }
     });
 
     it('ignore other keys', () => {
@@ -104,6 +108,10 @@ describe('MonthCalendar', () => {
       });
       expect(wrapper.state().value.month()).toBe(4);
       expect(wrapper.state().value.year()).toBe(2017);
+      const selectedValues = wrapper.find('.rc-calendar-month-panel-year-select-content');
+      for (let i = 0; i < selectedValues.length; i += 1) {
+        expect(selectedValues.at(i).text()).toBe('2017');
+      }
     });
   });
 


### PR DESCRIPTION
This PR relate to https://github.com/ant-design/ant-design/issues/15335 
Props name has been changed at father component, but child component haven't.