### PR TITLE
Fix Keyboard cannot control month calendar

### DIFF
--- a/src/calendar/CalendarHeader.jsx
+++ b/src/calendar/CalendarHeader.jsx
@@ -161,7 +161,7 @@ export default class CalendarHeader extends React.Component {
       panel = (
         <MonthPanel
           locale={locale}
-          defaultValue={value}
+          value={value}
           rootPrefixCls={prefixCls}
           onSelect={this.onMonthSelect}
           onYearPanelShow={() => this.showYearPanel('month')}

--- a/src/calendar/CalendarHeader.jsx
+++ b/src/calendar/CalendarHeader.jsx
@@ -75,6 +75,14 @@ export default class CalendarHeader extends React.Component {
     this.props.onValueChange(value);
   }
 
+  changeYear = (direction) => {
+    if (direction > 0) {
+      this.nextYear();
+    } else {
+      this.previousYear();
+    }
+  }
+
   monthYearElement = (showTimePicker) => {
     const props = this.props;
     const prefixCls = props.prefixCls;
@@ -161,6 +169,7 @@ export default class CalendarHeader extends React.Component {
           cellRender={props.monthCellRender}
           contentRender={props.monthCellContentRender}
           renderFooter={renderFooter}
+          changeYear={this.changeYear}
         />
       );
     }

--- a/src/month/MonthPanel.jsx
+++ b/src/month/MonthPanel.jsx
@@ -4,9 +4,7 @@ import { polyfill } from 'react-lifecycles-compat';
 import MonthTable from './MonthTable';
 
 function goYear(direction) {
-  const next = this.state.value.clone();
-  next.add(direction, 'year');
-  this.setAndChangeValue(next);
+  this.props.changeYear(direction);
 }
 
 function noop() {
@@ -41,22 +39,18 @@ class MonthPanel extends React.Component {
     };
   }
 
-  static getDerivedStateFromProps(nextProps) {
+  static getDerivedStateFromProps(props) {
     let newState = {};
 
-    if ('value' in nextProps) {
+    if ('defaultValue' in props) {
       newState = {
-        value: nextProps.value,
+        value: props.defaultValue,
       };
     }
 
     return newState;
   }
 
-  setAndChangeValue = (value) => {
-    this.setValue(value);
-    this.props.onChange(value);
-  }
 
   setAndSelectValue = (value) => {
     this.setValue(value);

--- a/src/month/MonthPanel.jsx
+++ b/src/month/MonthPanel.jsx
@@ -42,9 +42,9 @@ class MonthPanel extends React.Component {
   static getDerivedStateFromProps(props) {
     let newState = {};
 
-    if ('defaultValue' in props) {
+    if ('value' in props) {
       newState = {
-        value: props.defaultValue,
+        value: props.value,
       };
     }
 
@@ -58,7 +58,7 @@ class MonthPanel extends React.Component {
   }
 
   setValue = (value) => {
-    if (!('value' in this.props)) {
+    if ('value' in this.props) {
       this.setState({
         value,
       });

--- a/tests/MonthCalendar.spec.js
+++ b/tests/MonthCalendar.spec.js
@@ -87,6 +87,10 @@ describe('MonthCalendar', () => {
       });
       expect(wrapper.state().value.month()).toBe(4);
       expect(wrapper.state().value.year()).toBe(2016);
+      const selectedYear = wrapper.find('.rc-calendar-month-panel-year-select-content');
+      for (let i = 0; i < selectedYear.length; i += 1) {
+        expect(selectedYear.at(i).text()).toBe('2016');
+      }
     });
 
     it('CTRL + RIGHT', () => {
@@ -96,6 +100,10 @@ describe('MonthCalendar', () => {
       });
       expect(wrapper.state().value.month()).toBe(4);
       expect(wrapper.state().value.year()).toBe(2018);
+      const selectedYear = wrapper.find('.rc-calendar-month-panel-year-select-content');
+      for (let i = 0; i < selectedYear.length; i += 1) {
+        expect(selectedYear.at(i).text()).toBe('2018');
+      }
     });
 
     it('ignore other keys', () => {
@@ -104,6 +112,10 @@ describe('MonthCalendar', () => {
       });
       expect(wrapper.state().value.month()).toBe(4);
       expect(wrapper.state().value.year()).toBe(2017);
+      const selectedYear = wrapper.find('.rc-calendar-month-panel-year-select-content');
+      for (let i = 0; i < selectedYear.length; i += 1) {
+        expect(selectedYear.at(i).text()).toBe('2017');
+      }
     });
   });
 

--- a/tests/MonthCalendar.spec.js
+++ b/tests/MonthCalendar.spec.js
@@ -88,9 +88,7 @@ describe('MonthCalendar', () => {
       expect(wrapper.state().value.month()).toBe(4);
       expect(wrapper.state().value.year()).toBe(2016);
       const selectedYear = wrapper.find('.rc-calendar-month-panel-year-select-content');
-      for (let i = 0; i < selectedYear.length; i += 1) {
-        expect(selectedYear.at(i).text()).toBe('2016');
-      }
+      expect(selectedYear.at(0).text()).toBe('2016');
     });
 
     it('CTRL + RIGHT', () => {
@@ -101,9 +99,7 @@ describe('MonthCalendar', () => {
       expect(wrapper.state().value.month()).toBe(4);
       expect(wrapper.state().value.year()).toBe(2018);
       const selectedYear = wrapper.find('.rc-calendar-month-panel-year-select-content');
-      for (let i = 0; i < selectedYear.length; i += 1) {
-        expect(selectedYear.at(i).text()).toBe('2018');
-      }
+      expect(selectedYear.at(0).text()).toBe('2018');
     });
 
     it('ignore other keys', () => {
@@ -113,9 +109,7 @@ describe('MonthCalendar', () => {
       expect(wrapper.state().value.month()).toBe(4);
       expect(wrapper.state().value.year()).toBe(2017);
       const selectedYear = wrapper.find('.rc-calendar-month-panel-year-select-content');
-      for (let i = 0; i < selectedYear.length; i += 1) {
-        expect(selectedYear.at(i).text()).toBe('2017');
-      }
+      expect(selectedYear.at(0).text()).toBe('2017');
     });
   });
 


### PR DESCRIPTION
This PR relate to ant-design/ant-design#15335
The problem is getDerivedStateFromProps() in MonthPanel.jsx, it will execute right after setState() in setValue(),
https://reactjs.org/docs/react-component.html?utm_source=caibaojian.com#static-getderivedstatefromprops
In getDerivedStateFromProps(), we assign value by the defaultValue in props, but props isn't change, so it won't update, so my solution is move click event out of MonthPanel, put it in CalendarHeader(), just use props to update state.