### PR TITLE
syncTime should also sync millisecond

### DIFF
--- a/src/util/index.js
+++ b/src/util/index.js
@@ -38,6 +38,7 @@ export function syncTime(from, to) {
   to.hour(from.hour());
   to.minute(from.minute());
   to.second(from.second());
+  to.millisecond(from.millisecond());
 }
 
 export function getTimeConfig(value, disabledTime) {


### PR DESCRIPTION
current implementation will cause the millisecond same as the now() value regardless of what's in defaultValue. 
Since millisecond is not shown in the UI, this will work like a unwanted hidden behavior and make things very hard to trouble shoot.