### PR TITLE
fix antd-calendar example where calendar doesn't remain open on click

### DIFF
--- a/examples/antd-calendar.js
+++ b/examples/antd-calendar.js
@@ -109,9 +109,23 @@ class Demo extends React.Component {
     });
   }
 
-  onReadOnlyFocus = () => {
+  onFocus = () => {
+    if (!this.state.open && this.state.isMouseDown) {
+      // focus from a "click" event, let the picker trigger automatically open the calendar
+      this.setState({
+        isMouseDown: false,
+      });
+    } else {
+      // focus not caused by "click" (such as programmatic or via keyboard)
+      this.setState({
+        open: true,
+      });
+    }
+  }
+
+  onMouseDown = () => {
     this.setState({
-      open: true,
+      isMouseDown: true,
     });
   }
 
@@ -187,7 +201,7 @@ class Demo extends React.Component {
           {
             ({ value }) => {
               return (
-                <span tabIndex="0" onFocus={this.onReadOnlyFocus}>
+                <span tabIndex="0" onMouseDown={this.onMouseDown} onFocus={this.onFocus}>
                   <input
                     placeholder="please select"
                     style={{ width: 250 }}


### PR DESCRIPTION
on the _antd-calendar_ example, the date picker closes as soon as it opens when clicking on the picker input. 

This happens because the `onFocus` event handler of the wrapping `span` sets the picker `open` prop to `true`, but the _click_ event of the `rc-trigger` then toggles `open` back to `false`.

The fix is to let `rc-trigger` open the calendar when focus is caused by a _click._
