### PR TITLE
feat: Applying Hindu–Arabic numeral system for Arabic locale

### DIFF
--- a/src/date/DateTBody.jsx
+++ b/src/date/DateTBody.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import DateConstants from './DateConstants';
-import { getTitleString, getTodayTime } from '../util/';
+import { getTitleString, getTodayTime, memomizedNumeralsConverter } from '../util';
 
 function isSameDay(one, two) {
   return one && two && one.isSame(two, 'day');
@@ -49,7 +49,7 @@ export default class DateTBody extends React.Component {
     const {
       contentRender, prefixCls, selectedValue, value,
       showWeekNumber, dateRender, disabledDate,
-      hoverValue,
+      hoverValue, locale,
     } = props;
     let iIndex;
     let jIndex;
@@ -217,7 +217,8 @@ export default class DateTBody extends React.Component {
               aria-selected={selected}
               aria-disabled={disabled}
             >
-              {content}
+              {locale.numerals ?
+                memomizedNumeralsConverter(content, locale.numerals) : content}
             </div>);
         }
 

--- a/src/decade/DecadePanel.jsx
+++ b/src/decade/DecadePanel.jsx
@@ -109,7 +109,6 @@ export default class DecadePanel extends React.Component {
           />
 
           <div className={`${prefixCls}-century`}>
-            {/* {startYear}-{endYear} */}
             {locale.numerals ?
               `${memomizedNumeralsConverter(startYear, locale.numerals)}
                 -${memomizedNumeralsConverter(endYear, locale.numerals)}` :

--- a/src/decade/DecadePanel.jsx
+++ b/src/decade/DecadePanel.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import { memomizedNumeralsConverter } from '../util';
 const ROW = 4;
 const COL = 3;
-import classnames from 'classnames';
 
 function goYear(direction) {
   const next = this.state.value.clone();
@@ -89,7 +90,8 @@ export default class DecadePanel extends React.Component {
           <a
             className={`${prefixCls}-decade`}
           >
-            {content}
+            {locale.numerals ?
+              memomizedNumeralsConverter(content, locale.numerals) : content}
           </a>
         </td>);
       });
@@ -107,7 +109,11 @@ export default class DecadePanel extends React.Component {
           />
 
           <div className={`${prefixCls}-century`}>
-            {startYear}-{endYear}
+            {/* {startYear}-{endYear} */}
+            {locale.numerals ?
+              `${memomizedNumeralsConverter(startYear, locale.numerals)}
+                -${memomizedNumeralsConverter(endYear, locale.numerals)}` :
+              `${startYear}-${endYear}`}
           </div>
           <a
             className={`${prefixCls}-next-century-btn`}

--- a/src/full-calendar/CalendarHeader.jsx
+++ b/src/full-calendar/CalendarHeader.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { getMonthName } from '../util';
+import { getMonthName, memomizedNumeralsConverter } from '../util';
 
 function noop() {
 }
@@ -19,13 +19,17 @@ class CalendarHeader extends Component {
   }
 
   yearSelectElement(year) {
-    const { yearSelectOffset, yearSelectTotal, prefixCls, Select } = this.props;
+    const { yearSelectOffset, yearSelectTotal, prefixCls, Select, locale } = this.props;
     const start = year - yearSelectOffset;
     const end = start + yearSelectTotal;
 
     const options = [];
     for (let index = start; index < end; index++) {
-      options.push(<Select.Option key={`${index}`}>{index}</Select.Option>);
+      options.push(
+        <Select.Option key={`${index}`}>
+          {locale.numerals ? memomizedNumeralsConverter(index, locale.numerals) : index}
+        </Select.Option>
+      );
     }
     return (
       <Select

--- a/src/locale/ar_EG.js
+++ b/src/locale/ar_EG.js
@@ -24,4 +24,5 @@ export default {
   nextDecade: 'العقد التالى',
   previousCentury: 'القرن السابق',
   nextCentury: 'القرن التالى',
+  numerals: '٠,١,٢,٣,٤,٥,٦,٧,٨,٩',
 };

--- a/src/month/MonthPanel.jsx
+++ b/src/month/MonthPanel.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { polyfill } from 'react-lifecycles-compat';
 import MonthTable from './MonthTable';
+import { memomizedNumeralsConverter } from '../util';
 
 function goYear(direction) {
   this.props.changeYear(direction);
@@ -91,7 +92,9 @@ class MonthPanel extends React.Component {
               onClick={props.onYearPanelShow}
               title={locale.yearSelect}
             >
-              <span className={`${prefixCls}-year-select-content`}>{year}</span>
+              <span className={`${prefixCls}-year-select-content`}>
+                {locale.numerals ? memomizedNumeralsConverter(year, locale.numerals) : year}
+              </span>
               <span className={`${prefixCls}-year-select-arrow`}>x</span>
             </a>
 

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -102,3 +102,35 @@ export function formatDate(value, format) {
 
   return value.format(format);
 }
+
+function memo(func) {
+  const cache = {};
+  return function internalMemo() {
+      // Memomization using only the first argument
+      // as the second argument is constant during the conversion
+    const key = JSON.stringify(arguments[0]);
+    if (cache[key]) {
+      return cache[key];
+    }
+    const val = func.apply(null, arguments);
+    cache[key] = val;
+    return val;
+  };
+}
+
+function convertNumerals(numeral, numerals) {
+  const numeralsArr = numerals.split(',');
+  return String(numeral)
+    .replace(/0/g, numeralsArr[0])
+    .replace(/1/g, numeralsArr[1])
+    .replace(/2/g, numeralsArr[2])
+    .replace(/3/g, numeralsArr[3])
+    .replace(/4/g, numeralsArr[4])
+    .replace(/5/g, numeralsArr[5])
+    .replace(/6/g, numeralsArr[6])
+    .replace(/7/g, numeralsArr[7])
+    .replace(/8/g, numeralsArr[8])
+    .replace(/9/g, numeralsArr[9]);
+}
+
+export const memomizedNumeralsConverter = memo(convertNumerals);

--- a/src/year/YearPanel.jsx
+++ b/src/year/YearPanel.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { memomizedNumeralsConverter } from '../util';
+
 const ROW = 4;
 const COL = 3;
 
@@ -89,7 +91,9 @@ export default class YearPanel extends React.Component {
             <a
               className={`${prefixCls}-year`}
             >
-              {yearData.content}
+              {locale.numerals ?
+                memomizedNumeralsConverter(yearData.content, locale.numerals) :
+                yearData.content}
             </a>
           </td>);
       });
@@ -115,7 +119,10 @@ export default class YearPanel extends React.Component {
               title={locale.decadeSelect}
             >
               <span className={`${prefixCls}-decade-select-content`}>
-                {startYear}-{endYear}
+                {locale.numerals ?
+                  `${memomizedNumeralsConverter(startYear, locale.numerals)}
+                    -${memomizedNumeralsConverter(endYear, locale.numerals)}` :
+                  `${startYear}-${endYear}`}
               </span>
               <span className={`${prefixCls}-decade-select-arrow`}>x</span>
             </a>

--- a/tests/__snapshots__/locale.spec.js.snap
+++ b/tests/__snapshots__/locale.spec.js.snap
@@ -184,7 +184,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  26
+                  ٢٦
                 </div>
               </td>
               <td
@@ -197,7 +197,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  27
+                  ٢٧
                 </div>
               </td>
               <td
@@ -210,7 +210,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  28
+                  ٢٨
                 </div>
               </td>
               <td
@@ -223,7 +223,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  1
+                  ١
                 </div>
               </td>
               <td
@@ -236,7 +236,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  2
+                  ٢
                 </div>
               </td>
               <td
@@ -249,7 +249,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  3
+                  ٣
                 </div>
               </td>
               <td
@@ -262,7 +262,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  4
+                  ٤
                 </div>
               </td>
             </tr>
@@ -280,7 +280,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  5
+                  ٥
                 </div>
               </td>
               <td
@@ -293,7 +293,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  6
+                  ٦
                 </div>
               </td>
               <td
@@ -306,7 +306,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  7
+                  ٧
                 </div>
               </td>
               <td
@@ -319,7 +319,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  8
+                  ٨
                 </div>
               </td>
               <td
@@ -332,7 +332,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  9
+                  ٩
                 </div>
               </td>
               <td
@@ -345,7 +345,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  10
+                  ١٠
                 </div>
               </td>
               <td
@@ -358,7 +358,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  11
+                  ١١
                 </div>
               </td>
             </tr>
@@ -376,7 +376,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  12
+                  ١٢
                 </div>
               </td>
               <td
@@ -389,7 +389,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  13
+                  ١٣
                 </div>
               </td>
               <td
@@ -402,7 +402,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  14
+                  ١٤
                 </div>
               </td>
               <td
@@ -415,7 +415,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  15
+                  ١٥
                 </div>
               </td>
               <td
@@ -428,7 +428,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  16
+                  ١٦
                 </div>
               </td>
               <td
@@ -441,7 +441,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  17
+                  ١٧
                 </div>
               </td>
               <td
@@ -454,7 +454,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  18
+                  ١٨
                 </div>
               </td>
             </tr>
@@ -472,7 +472,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  19
+                  ١٩
                 </div>
               </td>
               <td
@@ -485,7 +485,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  20
+                  ٢٠
                 </div>
               </td>
               <td
@@ -498,7 +498,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  21
+                  ٢١
                 </div>
               </td>
               <td
@@ -511,7 +511,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  22
+                  ٢٢
                 </div>
               </td>
               <td
@@ -524,7 +524,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  23
+                  ٢٣
                 </div>
               </td>
               <td
@@ -537,7 +537,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  24
+                  ٢٤
                 </div>
               </td>
               <td
@@ -550,7 +550,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  25
+                  ٢٥
                 </div>
               </td>
             </tr>
@@ -568,7 +568,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  26
+                  ٢٦
                 </div>
               </td>
               <td
@@ -581,7 +581,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  27
+                  ٢٧
                 </div>
               </td>
               <td
@@ -594,7 +594,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  28
+                  ٢٨
                 </div>
               </td>
               <td
@@ -607,7 +607,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="true"
                   class="rc-calendar-date"
                 >
-                  29
+                  ٢٩
                 </div>
               </td>
               <td
@@ -620,7 +620,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  30
+                  ٣٠
                 </div>
               </td>
               <td
@@ -633,7 +633,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  31
+                  ٣١
                 </div>
               </td>
               <td
@@ -646,7 +646,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  1
+                  ١
                 </div>
               </td>
             </tr>
@@ -664,7 +664,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  2
+                  ٢
                 </div>
               </td>
               <td
@@ -677,7 +677,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  3
+                  ٣
                 </div>
               </td>
               <td
@@ -690,7 +690,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  4
+                  ٤
                 </div>
               </td>
               <td
@@ -703,7 +703,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  5
+                  ٥
                 </div>
               </td>
               <td
@@ -716,7 +716,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  6
+                  ٦
                 </div>
               </td>
               <td
@@ -729,7 +729,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  7
+                  ٧
                 </div>
               </td>
               <td
@@ -742,7 +742,7 @@ exports[`locales renders ar_EG correctly 1`] = `
                   aria-selected="false"
                   class="rc-calendar-date"
                 >
-                  8
+                  ٨
                 </div>
               </td>
             </tr>


### PR DESCRIPTION
Since #304 does not support Arabic numerals. This pull request focuses on offering a fully Arabic datepicker. Also, it does not break other languages numerals. Other languages that have a different numeral system such as Persian could also add their numerals to the Persian locale file and it would work immediately.

I understand that this adds more computations while rendering each value (year, day or decades), so I tried to memomize those translated values.

Another option was to use `.toLocaleString('ar-EG', { useGrouping: false })` instead of string replacement. Not so sure about which one is more optimized. However, I thought using existing locale files gives more flexibility.