### PR TITLE
month calendar compatible to react v15.x

### DIFF
--- a/src/MonthCalendar.jsx
+++ b/src/MonthCalendar.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import KeyCode from 'rc-util/lib/KeyCode';
+import { polyfill } from 'react-lifecycles-compat';
 import CalendarHeader from './calendar/CalendarHeader';
 import CalendarFooter from './calendar/CalendarFooter';
 import {
@@ -120,4 +121,4 @@ class MonthCalendar extends React.Component {
   }
 }
 
-export default calendarMixinWrapper(commonMixinWrapper(MonthCalendar));
+export default polyfill(calendarMixinWrapper(commonMixinWrapper(MonthCalendar)));


### PR DESCRIPTION
fix [Ant design MonthPicker切换年份时无法正常工作](https://github.com/ant-design/ant-design/issues/17292)