### PR TITLE
RangeCalendar format propType to work with array

### DIFF
--- a/src/RangeCalendar.js
+++ b/src/RangeCalendar.js
@@ -102,7 +102,7 @@ class RangeCalendar extends React.Component {
     onValueChange: PropTypes.func,
     onHoverChange: PropTypes.func,
     onPanelChange: PropTypes.func,
-    format: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+    format: PropTypes.any,
     onClear: PropTypes.func,
     type: PropTypes.any,
     disabledDate: PropTypes.func,


### PR DESCRIPTION
The `format` prop accepts both `string` and `string[]`.

Update the `format` prop type to match the underlying `CalendarPart` component.

Without this change, passing an array of formats to the `RangeCalendar` component works but results in a warning.