### PR TITLE
修复calendar组件在picker组件中使用时,selectValue无效问题

### DIFF
--- a/src/Picker.jsx
+++ b/src/Picker.jsx
@@ -150,7 +150,7 @@ class Picker extends React.Component {
     const extraProps = {
       ref: this.saveCalendarRef,
       defaultValue: defaultValue || calendarProps.defaultValue,
-      selectedValue: value,
+      selectedValue: value || calendarProps.selectedValue,
       onKeyDown: this.onCalendarKeyDown,
       onOk: createChainedFunction(calendarProps.onOk, this.onCalendarOk),
       onSelect: createChainedFunction(calendarProps.onSelect, this.onCalendarSelect),


### PR DESCRIPTION
问题描述：
picker组件的会拦截calendar的selectValue， 这个是有什么原因吗？
```
const calendar = (
            <Calendar selectValue={moment()}/>  // 此时calendar组件中的selectValue 为 undefined
        )
        return (
            <Picker calendar={calendar}>
                {this.renderChild}
            </Picker>
        );
```